### PR TITLE
feat: add Alloy.Persistence behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-02-28
+
+### Added
+
+- **Persistence behaviour** — `Alloy.Persistence` defines the formal contract for session persistence backends (`save_session/1`, `load_session/1`, `delete_session/1`, `list_sessions/0`). Alloy itself remains in-memory only — this behaviour is the architectural seam between the engine and any runtime (AnvilOS, or your own Ecto/SQLite/Redis adapter).
+
 ## [0.4.0] - 2026-02-26
 
 ### Added

--- a/lib/alloy/persistence.ex
+++ b/lib/alloy/persistence.ex
@@ -1,0 +1,88 @@
+defmodule Alloy.Persistence do
+  @moduledoc """
+  Optional behaviour for session persistence backends.
+
+  Defines the contract that host applications implement to persist
+  agent sessions. Alloy itself is in-memory only — this behaviour
+  is the formal seam between the engine and any runtime that adds
+  durability (e.g., AnvilOS, or your own Ecto/SQLite/Redis adapter).
+
+  ## Implementing a backend
+
+      defmodule MyApp.SessionStore do
+        @behaviour Alloy.Persistence
+
+        @impl true
+        def save_session(%Alloy.Session{} = session) do
+          # Write to your database
+          :ok
+        end
+
+        @impl true
+        def load_session(id) do
+          case Repo.get(SessionSchema, id) do
+            nil -> {:error, :not_found}
+            record -> {:ok, to_session(record)}
+          end
+        end
+
+        @impl true
+        def delete_session(id) do
+          Repo.delete_all(from s in SessionSchema, where: s.id == ^id)
+          :ok
+        end
+
+        @impl true
+        def list_sessions do
+          Repo.all(SessionSchema) |> Enum.map(&to_session/1)
+        end
+      end
+
+  ## Wiring it up
+
+  Pass your store module to `Alloy.Agent.Server` via middleware or
+  the `:on_shutdown` callback:
+
+      Alloy.Agent.Server.start_link(
+        provider: {Alloy.Provider.Anthropic, api_key: key, model: "claude-opus-4-6"},
+        on_shutdown: fn session -> MyApp.SessionStore.save_session(session) end
+      )
+
+  Or use middleware for automatic persistence after every turn:
+
+      defmodule PersistMiddleware do
+        @behaviour Alloy.Middleware
+
+        @impl true
+        def call(:after_completion, state) do
+          session = Alloy.Session.new(messages: state.messages, usage: state.usage)
+          MyApp.SessionStore.save_session(session)
+          state
+        end
+
+        def call(_hook, state), do: state
+      end
+  """
+
+  alias Alloy.Session
+
+  @doc """
+  Persist a session. Overwrites any existing session with the same ID.
+  """
+  @callback save_session(Session.t()) :: :ok | {:error, term()}
+
+  @doc """
+  Load a session by ID. Returns `{:error, :not_found}` if it doesn't exist.
+  """
+  @callback load_session(String.t()) :: {:ok, Session.t()} | {:error, :not_found | term()}
+
+  @doc """
+  Delete a session by ID. Succeeds silently if the session doesn't exist.
+  """
+  @callback delete_session(String.t()) :: :ok | {:error, term()}
+
+  @doc """
+  List all persisted sessions.
+  """
+  @callback list_sessions() :: [Session.t()]
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do
@@ -62,6 +62,7 @@ defmodule Alloy.MixProject do
           Alloy.Agent.State,
           Alloy.Agent.Turn,
           Alloy.Message,
+          Alloy.Persistence,
           Alloy.Session,
           Alloy.Usage
         ],

--- a/test/alloy/persistence_test.exs
+++ b/test/alloy/persistence_test.exs
@@ -1,0 +1,123 @@
+defmodule Alloy.PersistenceTest do
+  use ExUnit.Case, async: true
+
+  alias Alloy.{Session, Usage}
+
+  # A minimal in-memory implementation to verify the behaviour contract.
+  defmodule InMemoryStore do
+    @behaviour Alloy.Persistence
+
+    use Agent
+
+    def start_link(_opts \\ []) do
+      Agent.start_link(fn -> %{} end, name: __MODULE__)
+    end
+
+    @impl Alloy.Persistence
+    def save_session(%Session{} = session) do
+      Agent.update(__MODULE__, &Map.put(&1, session.id, session))
+      :ok
+    end
+
+    @impl Alloy.Persistence
+    def load_session(id) when is_binary(id) do
+      case Agent.get(__MODULE__, &Map.get(&1, id)) do
+        nil -> {:error, :not_found}
+        session -> {:ok, session}
+      end
+    end
+
+    @impl Alloy.Persistence
+    def delete_session(id) when is_binary(id) do
+      Agent.update(__MODULE__, &Map.delete(&1, id))
+      :ok
+    end
+
+    @impl Alloy.Persistence
+    def list_sessions do
+      Agent.get(__MODULE__, &Map.values(&1))
+    end
+  end
+
+  setup do
+    {:ok, _} = InMemoryStore.start_link()
+    :ok
+  end
+
+  describe "behaviour contract" do
+    test "module defines the expected callbacks" do
+      callbacks = Alloy.Persistence.behaviour_info(:callbacks)
+
+      assert {:save_session, 1} in callbacks
+      assert {:load_session, 1} in callbacks
+      assert {:delete_session, 1} in callbacks
+      assert {:list_sessions, 0} in callbacks
+    end
+  end
+
+  describe "save_session/1 + load_session/1" do
+    test "round-trips a session" do
+      session = Session.new(id: "test-123", metadata: %{agent: "tester"})
+
+      assert :ok = InMemoryStore.save_session(session)
+      assert {:ok, loaded} = InMemoryStore.load_session("test-123")
+
+      assert loaded.id == "test-123"
+      assert loaded.metadata == %{agent: "tester"}
+      assert loaded.messages == []
+      assert %Usage{} = loaded.usage
+    end
+
+    test "overwrites existing session on re-save" do
+      session = Session.new(id: "overwrite-1")
+      assert :ok = InMemoryStore.save_session(session)
+
+      updated =
+        Session.update_from_result(session, %{
+          messages: [%Alloy.Message{role: :user, content: "hello"}],
+          usage: %Usage{input_tokens: 10}
+        })
+
+      assert :ok = InMemoryStore.save_session(updated)
+      assert {:ok, loaded} = InMemoryStore.load_session("overwrite-1")
+      assert length(loaded.messages) == 1
+      assert loaded.usage.input_tokens == 10
+    end
+  end
+
+  describe "load_session/1 not found" do
+    test "returns {:error, :not_found} for missing session" do
+      assert {:error, :not_found} = InMemoryStore.load_session("nonexistent")
+    end
+  end
+
+  describe "delete_session/1" do
+    test "removes a previously saved session" do
+      session = Session.new(id: "delete-me")
+      assert :ok = InMemoryStore.save_session(session)
+      assert {:ok, _} = InMemoryStore.load_session("delete-me")
+
+      assert :ok = InMemoryStore.delete_session("delete-me")
+      assert {:error, :not_found} = InMemoryStore.load_session("delete-me")
+    end
+
+    test "succeeds silently for missing session" do
+      assert :ok = InMemoryStore.delete_session("never-existed")
+    end
+  end
+
+  describe "list_sessions/0" do
+    test "returns all saved sessions" do
+      assert InMemoryStore.list_sessions() == []
+
+      s1 = Session.new(id: "list-1")
+      s2 = Session.new(id: "list-2")
+      InMemoryStore.save_session(s1)
+      InMemoryStore.save_session(s2)
+
+      sessions = InMemoryStore.list_sessions()
+      ids = Enum.map(sessions, & &1.id) |> Enum.sort()
+      assert ids == ["list-1", "list-2"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Alloy.Persistence` behaviour — the formal contract for session persistence backends
- 4 callbacks: `save_session/1`, `load_session/1`, `delete_session/1`, `list_sessions/0`
- Alloy itself stays in-memory only — this is the architectural seam between engine and runtime (AnvilOS)
- Includes 7 tests with InMemoryStore reference implementation
- Bumps version to 0.4.1

## Context
Model Council (Codex + Gemini + Opus) unanimously identified this as the one missing feature before Alloy's scope is complete. The persistence behaviour defines the boundary: Alloy answers "what should the agent think and do?", AnvilOS answers "how should the agent live and persist?"

## Test plan
- [x] 7 new tests covering behaviour contract, round-trip, overwrite, not-found, delete, list
- [x] Full suite passes (477 tests, 0 failures)
- [x] Credo clean, format clean
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)