### PR TITLE
feat: Alloy.Result struct + OTP hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Alloy.Result` struct** — typed, `Access`-compatible return value from `Alloy.run/2` and `Server.chat/3`. Single source of truth for the 8-field result contract. Implements `Access` behaviour for bracket-syntax backwards compatibility (`result[:text]`).
 - **Anthropic code execution support** — configure `code_execution: true` to enable Anthropic's server-side Python sandbox. Alloy handles `server_tool_use` / `server_tool_result` round-trips across Message, Executor, and Anthropic provider layers. The `code_execution_20250522` tool type is appended to the request body when enabled.
 - **Optional tool callbacks** — `Alloy.Tool` behaviour gains `allowed_callers/0` and `result_type/0` as `@optional_callbacks`. Tools that don't implement them compile and work as before. Registry uses `function_exported?/3` to conditionally include metadata in tool definitions.
 - **Structured tool results** — tools can return `{:ok, text, data}` 3-tuples. Text goes into the result block (what the model sees), structured data goes into `meta.structured_data` for programmatic consumption (e.g., by a code execution sandbox).
 - **`allowed_callers` forwarding** — Anthropic provider includes `allowed_callers` in the tool definition sent to the API when present, enabling tools to declare whether they can be invoked from a code execution sandbox.
+- **`server_tool_use`/`server_tool_result` token counting** — `TokenCounter` now estimates tokens for server tool blocks, preventing compaction from underestimating context size when code execution is in use.
+- **Thinking block truncation in compactor** — thinking blocks exceeding the truncation length are sliced during compaction, reducing context size for extended thinking conversations.
+- **`Testing.last_text/1` accepts `%State{}`** — delegates to `State.last_assistant_text/1` when given a `%State{}` struct, avoiding redundant reverse-search logic.
 
 ### Changed
 
+- **`pending_requests` migrated to `:queue`** — `State.pending_requests` changed from a plain list to an Erlang `:queue` for O(1) enqueue/dequeue. All Server functions (`enqueue_pending_request`, `maybe_start_next_pending`, `remove_pending_request`, `health`) updated accordingly.
+- **`agent_event` handler now async** — `handle_info({:agent_event, message})` now dispatches via `start_async_turn/3` (supervised Task) instead of running the Turn synchronously in the GenServer process. Prevents blocking the GenServer mailbox during long-running turns.
+- **`handle_info` catchall logs unexpected messages** — the catch-all `handle_info/2` now logs via `Logger.debug/1` instead of silently discarding unknown messages.
+- **`on_shutdown` crash logging** — `terminate/2` now logs `Logger.warning` with the exception and stacktrace when `on_shutdown` callbacks crash, instead of silently swallowing.
+- **`:after_tool_request` middleware hook** — renamed from `:after_completion` in the tool-use code path. `:after_completion` now fires only on `:end_turn` (final response). `:after_tool_request` gates tool execution.
+- **`within_budget?/3` accepts configurable ratio** — third parameter (default `0.9`) replaces the hardcoded 90% budget threshold.
+- **SSE parser crash logging** — `SSE.parse_stream` now logs `Logger.warning` with exception message and stacktrace when an event handler crashes, instead of silently recovering.
+- **Executor crash logging** — `Executor.run_tagged` now captures `__STACKTRACE__` and logs `Logger.warning` with tool name and stacktrace when a tool crashes.
 - **Compactor refactor** — extracted `split_messages/2` to DRY message splitting between `compact/2` and `fire_on_compaction`. The `on_compaction` callback now receives the middle slice directly instead of the full message list + keep_recent count.
 - **Executor result dispatch** — `result_block_fn/1` dispatches to `Message.tool_result_block/3` or `Message.server_tool_result_block/3` based on call type, so timeout and crash results also respect the call type.
 - **`Message.tool_calls/1`** — now matches both `"tool_use"` and `"server_tool_use"` block types.
 - **`Alloy.Tool.execute/2` return type** — widened to `{:ok, String.t()} | {:ok, String.t(), map()} | {:error, String.t()}`.
+
+### Breaking
+
+- **Middleware hook `:after_completion` no longer fires on tool-use responses** — use `:after_tool_request` for middleware that should gate tool execution. `:after_completion` now only fires on `:end_turn` (the model's final response).
 
 ## [0.6.0] - 2026-03-02
 

--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -44,17 +44,9 @@ defmodule Alloy do
   """
 
   alias Alloy.Agent.{Config, Server, State, Turn}
-  alias Alloy.Message
+  alias Alloy.{Message, Result}
 
-  @type result :: %{
-          text: String.t() | nil,
-          messages: [Message.t()],
-          usage: Alloy.Usage.t(),
-          tool_calls: [map()],
-          status: State.status(),
-          turns: non_neg_integer(),
-          error: term() | nil
-        }
+  @type result :: Result.t()
 
   @doc """
   Send a message to a running agent without blocking the caller.
@@ -91,7 +83,7 @@ defmodule Alloy do
     try do
       final_state = Turn.run_loop(state)
 
-      result = %{
+      result = %Result{
         text: State.last_assistant_text(final_state),
         messages: State.messages(final_state),
         usage: final_state.usage,

--- a/lib/alloy/agent/server.ex
+++ b/lib/alloy/agent/server.ex
@@ -41,17 +41,9 @@ defmodule Alloy.Agent.Server do
   require Logger
 
   alias Alloy.Agent.{Config, State, Turn}
-  alias Alloy.{Message, Middleware, Session, Usage}
+  alias Alloy.{Message, Middleware, Result, Session, Usage}
 
-  @type result :: %{
-          text: String.t() | nil,
-          messages: [Message.t()],
-          usage: Usage.t(),
-          tool_calls: [map()],
-          status: State.status(),
-          turns: non_neg_integer(),
-          error: term() | nil
-        }
+  @type result :: Result.t()
 
   # ── Client API ────────────────────────────────────────────────────────────
 
@@ -297,9 +289,15 @@ defmodule Alloy.Agent.Server do
       try do
         state.config.on_shutdown.(session)
       rescue
-        _ -> :ok
+        e ->
+          Logger.warning(
+            "[Alloy] on_shutdown callback raised: #{inspect(e)}\n#{Exception.format_stacktrace(__STACKTRACE__)}"
+          )
       catch
-        _, _ -> :ok
+        kind, reason ->
+          Logger.warning(
+            "[Alloy] on_shutdown callback threw #{inspect(kind)}: #{inspect(reason)}"
+          )
       end
     end
 
@@ -382,7 +380,10 @@ defmodule Alloy.Agent.Server do
 
   @impl GenServer
   def handle_call(:reset, _from, state) do
-    new_state = %{state | messages: [], messages_new: []} |> reset_for_new_run()
+    new_state =
+      %{state | messages: [], messages_new: [], pending_requests: :queue.new()}
+      |> reset_for_new_run()
+
     {:reply, :ok, new_state}
   end
 
@@ -419,7 +420,7 @@ defmodule Alloy.Agent.Server do
        usage: state.usage,
        uptime_ms: System.monotonic_time(:millisecond) - (state.started_at || 0),
        busy: state.current_task != nil,
-       pending_count: length(state.pending_requests),
+       pending_count: :queue.len(state.pending_requests),
        max_pending: state.config.max_pending
      }, state}
   end
@@ -436,7 +437,7 @@ defmodule Alloy.Agent.Server do
       state.current_task == nil ->
         {:reply, {:ok, request_id}, start_async_turn(state, message, request_id)}
 
-      length(state.pending_requests) < state.config.max_pending ->
+      :queue.len(state.pending_requests) < state.config.max_pending ->
         {:reply, {:ok, request_id}, enqueue_pending_request(state, message, request_id)}
 
       state.config.max_pending == 0 ->
@@ -494,26 +495,8 @@ defmodule Alloy.Agent.Server do
 
   @impl GenServer
   def handle_info({:agent_event, message}, state) when is_binary(message) do
-    state =
-      state
-      |> State.append_messages([Message.user(message)])
-      |> reset_for_new_run()
-      |> set_running()
-
-    final_state = Turn.run_loop(state)
-
-    # Broadcast result if pubsub is configured.
-    # Use effective_session_id/1 so the topic matches what export_session/1
-    # returns as the session ID — a :session_start middleware that injects
-    # context[:session_id] would otherwise cause the broadcast topic to
-    # diverge from the exported session ID, dropping messages for subscribers
-    # that subscribe using the session ID.
-    if state.config.pubsub do
-      topic = "agent:#{effective_session_id(final_state)}:responses"
-      broadcast(state.config.pubsub, topic, {:agent_response, build_result(final_state)})
-    end
-
-    {:noreply, final_state}
+    request_id = generate_request_id()
+    {:noreply, start_async_turn(state, message, request_id)}
   end
 
   # Task completed successfully — broadcast result and free the agent.
@@ -526,7 +509,7 @@ defmodule Alloy.Agent.Server do
 
     if final_state.config.pubsub do
       topic = "agent:#{effective_session_id(final_state)}:responses"
-      result = final_state |> build_result() |> Map.put(:request_id, request_id)
+      result = %{build_result(final_state) | request_id: request_id}
       broadcast(final_state.config.pubsub, topic, {:agent_response, result})
     end
 
@@ -592,7 +575,8 @@ defmodule Alloy.Agent.Server do
   end
 
   @impl GenServer
-  def handle_info(_msg, state) do
+  def handle_info(msg, state) do
+    Logger.debug("[Alloy] Unexpected message: #{inspect(msg)}")
     {:noreply, state}
   end
 
@@ -656,35 +640,29 @@ defmodule Alloy.Agent.Server do
 
   defp enqueue_pending_request(%State{} = state, message, request_id)
        when is_binary(message) and is_binary(request_id) do
-    %{state | pending_requests: state.pending_requests ++ [{message, request_id}]}
+    %{state | pending_requests: :queue.in({message, request_id}, state.pending_requests)}
   end
 
-  defp maybe_start_next_pending(%State{current_task: nil, pending_requests: []} = state),
-    do: state
+  defp maybe_start_next_pending(%State{current_task: nil} = state) do
+    case :queue.out(state.pending_requests) do
+      {:empty, _} ->
+        state
 
-  defp maybe_start_next_pending(%State{pending_requests: [{message, request_id} | rest]} = state) do
-    state
-    |> Map.put(:pending_requests, rest)
-    |> start_async_turn(message, request_id)
-  end
-
-  defp remove_pending_request(%State{} = state, request_id) when is_binary(request_id) do
-    {removed?, pending_requests} = pop_pending_request(state.pending_requests, request_id, [])
-
-    if removed? do
-      {:ok, %{state | pending_requests: pending_requests}}
-    else
-      :not_found
+      {{:value, {message, request_id}}, rest} ->
+        state
+        |> Map.put(:pending_requests, rest)
+        |> start_async_turn(message, request_id)
     end
   end
 
-  defp pop_pending_request([], _request_id, acc), do: {false, Enum.reverse(acc)}
+  defp remove_pending_request(%State{} = state, request_id) when is_binary(request_id) do
+    items = :queue.to_list(state.pending_requests)
 
-  defp pop_pending_request([{_message, request_id} | rest], request_id, acc),
-    do: {true, Enum.reverse(acc) ++ rest}
-
-  defp pop_pending_request([entry | rest], request_id, acc),
-    do: pop_pending_request(rest, request_id, [entry | acc])
+    case Enum.reject(items, fn {_msg, rid} -> rid == request_id end) do
+      ^items -> :not_found
+      filtered -> {:ok, %{state | pending_requests: :queue.from_list(filtered)}}
+    end
+  end
 
   defp broadcast_cancelled(%State{config: %{pubsub: nil}}, _request_id, _phase), do: :ok
 
@@ -709,7 +687,7 @@ defmodule Alloy.Agent.Server do
   end
 
   defp build_result(%State{} = state) do
-    %{
+    %Result{
       text: State.last_assistant_text(state),
       messages: State.messages(state),
       usage: state.usage,

--- a/lib/alloy/agent/state.ex
+++ b/lib/alloy/agent/state.ex
@@ -14,6 +14,7 @@ defmodule Alloy.Agent.State do
   @type t :: %__MODULE__{
           config: Config.t(),
           messages: [Message.t()],
+          messages_new: [Message.t()],
           turn: non_neg_integer(),
           usage: Usage.t(),
           status: status(),
@@ -24,7 +25,7 @@ defmodule Alloy.Agent.State do
           started_at: integer() | nil,
           agent_id: String.t(),
           current_task: {reference(), pid(), binary()} | nil,
-          pending_requests: [{String.t(), binary()}]
+          pending_requests: :queue.queue({String.t(), binary()})
         }
 
   @enforce_keys [:config]
@@ -42,7 +43,7 @@ defmodule Alloy.Agent.State do
     started_at: nil,
     agent_id: "",
     current_task: nil,
-    pending_requests: []
+    pending_requests: :queue.new()
   ]
 
   @doc """

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -130,7 +130,7 @@ defmodule Alloy.Agent.Turn do
   end
 
   defp handle_tool_use(%State{} = state, new_msgs, opts, deadline) do
-    case Middleware.run(:after_completion, state) do
+    case Middleware.run(:after_tool_request, state) do
       {:halted, reason} ->
         %{state | status: :halted, error: "Halted by middleware: #{reason}"}
 

--- a/lib/alloy/context/compactor.ex
+++ b/lib/alloy/context/compactor.ex
@@ -101,8 +101,14 @@ defmodule Alloy.Context.Compactor do
   defp compact_message(%Message{content: blocks} = msg) when is_list(blocks) do
     compacted_blocks =
       Enum.map(blocks, fn
-        %{type: "tool_result"} = block -> %{block | content: "[compacted]"}
-        block -> block
+        %{type: "tool_result"} = block ->
+          %{block | content: "[compacted]"}
+
+        %{type: "thinking", thinking: text} = block when byte_size(text) > @truncate_length ->
+          %{block | thinking: String.slice(text, 0, @truncate_length) <> "..."}
+
+        block ->
+          block
       end)
 
     %{msg | content: compacted_blocks}

--- a/lib/alloy/context/token_counter.ex
+++ b/lib/alloy/context/token_counter.ex
@@ -29,6 +29,7 @@ defmodule Alloy.Context.TokenCounter do
   }
 
   @default_limit 200_000
+  @default_budget_ratio 0.9
 
   @doc """
   Estimates tokens for a string or a list of messages.
@@ -69,8 +70,14 @@ defmodule Alloy.Context.TokenCounter do
 
   defp estimate_block_tokens(%{type: "tool_use", name: name, input: input}) do
     name_tokens = estimate_tokens(to_string(name))
-    input_tokens = estimate_tokens(Jason.encode!(input))
-    name_tokens + input_tokens
+
+    input_str =
+      case Jason.encode(input) do
+        {:ok, json} -> json
+        {:error, _} -> inspect(input)
+      end
+
+    name_tokens + estimate_tokens(input_str)
   end
 
   defp estimate_block_tokens(%{type: "tool_result", content: content}) when is_binary(content) do
@@ -79,6 +86,23 @@ defmodule Alloy.Context.TokenCounter do
 
   defp estimate_block_tokens(%{type: "thinking", thinking: text}) when is_binary(text) do
     estimate_tokens(text)
+  end
+
+  defp estimate_block_tokens(%{type: "server_tool_use", name: name, input: input}) do
+    name_tokens = estimate_tokens(to_string(name))
+
+    input_str =
+      case Jason.encode(input) do
+        {:ok, json} -> json
+        {:error, _} -> inspect(input)
+      end
+
+    name_tokens + estimate_tokens(input_str)
+  end
+
+  defp estimate_block_tokens(%{type: "server_tool_result", content: content})
+       when is_binary(content) do
+    estimate_tokens(content)
   end
 
   defp estimate_block_tokens(%{type: "image"}), do: @image_tokens
@@ -99,10 +123,10 @@ defmodule Alloy.Context.TokenCounter do
 
   @doc """
   Returns true if the estimated token count of messages is within
-  90% of the max_tokens budget.
+  the given ratio of the max_tokens budget (default #{@default_budget_ratio}).
   """
-  @spec within_budget?([Message.t()], pos_integer()) :: boolean()
-  def within_budget?(messages, max_tokens) do
-    estimate_tokens(messages) < max_tokens * 0.9
+  @spec within_budget?([Message.t()], pos_integer(), float()) :: boolean()
+  def within_budget?(messages, max_tokens, ratio \\ @default_budget_ratio) do
+    estimate_tokens(messages) < max_tokens * ratio
   end
 end

--- a/lib/alloy/middleware.ex
+++ b/lib/alloy/middleware.ex
@@ -4,7 +4,8 @@ defmodule Alloy.Middleware do
 
   Middleware runs at defined hook points:
   - `:before_completion` - Before calling the provider
-  - `:after_completion` - After provider response, before tool execution
+  - `:after_completion` - After provider response with :end_turn (final state)
+  - `:after_tool_request` - After provider response with :tool_use (gates tool execution)
   - `:after_tool_execution` - After tools have been executed
   - `:on_error` - When an error occurs
 
@@ -17,6 +18,7 @@ defmodule Alloy.Middleware do
   @type hook ::
           :before_completion
           | :after_completion
+          | :after_tool_request
           | :after_tool_execution
           | :on_error
           | :before_tool_call

--- a/lib/alloy/provider/sse.ex
+++ b/lib/alloy/provider/sse.ex
@@ -11,6 +11,8 @@ defmodule Alloy.Provider.SSE do
   on the parsed events returned here.
   """
 
+  require Logger
+
   @type sse_event :: %{event: String.t() | nil, data: String.t()}
 
   @doc """
@@ -67,7 +69,12 @@ defmodule Alloy.Provider.SSE do
           try do
             handle_event.(acc, event)
           rescue
-            _ -> acc
+            e ->
+              Logger.warning(
+                "SSE event handler crashed: #{Exception.message(e)}\n#{Exception.format_stacktrace(__STACKTRACE__)}"
+              )
+
+              acc
           end
         end)
 

--- a/lib/alloy/result.ex
+++ b/lib/alloy/result.ex
@@ -1,0 +1,60 @@
+defmodule Alloy.Result do
+  @moduledoc """
+  Structured result from an agent run.
+
+  Returned by `Alloy.run/2` and `Alloy.Agent.Server.chat/3`.
+  Implements `Access` for bracket-syntax compatibility (`result[:text]`).
+
+  ## Fields
+
+    * `:text` — the final assistant text (or `nil` if the model returned no text)
+    * `:messages` — full conversation history
+    * `:usage` — accumulated `%Alloy.Usage{}` token counts
+    * `:tool_calls` — list of tool execution metadata maps
+    * `:status` — final run status (`:completed`, `:max_turns`, `:error`, `:halted`)
+    * `:turns` — number of agent loop iterations
+    * `:error` — error term (or `nil` on success)
+    * `:request_id` — correlation ID for async requests (or `nil` for sync)
+  """
+
+  @behaviour Access
+
+  alias Alloy.Agent.State
+  alias Alloy.{Message, Usage}
+
+  @type t :: %__MODULE__{
+          text: String.t() | nil,
+          messages: [Message.t()],
+          usage: Usage.t(),
+          tool_calls: [map()],
+          status: State.status(),
+          turns: non_neg_integer(),
+          error: term() | nil,
+          request_id: binary() | nil
+        }
+
+  defstruct [
+    :text,
+    :error,
+    :request_id,
+    messages: [],
+    usage: %Usage{},
+    tool_calls: [],
+    status: :completed,
+    turns: 0
+  ]
+
+  # ── Access callbacks ─────────────────────────────────────────────────────
+
+  @impl Access
+  def fetch(result, key), do: Map.fetch(result, key)
+
+  @impl Access
+  def get_and_update(result, key, fun), do: Map.get_and_update(result, key, fun)
+
+  @impl Access
+  def pop(result, key) do
+    value = Map.get(result, key)
+    {value, Map.put(result, key, nil)}
+  end
+end

--- a/lib/alloy/testing.ex
+++ b/lib/alloy/testing.ex
@@ -115,6 +115,8 @@ defmodule Alloy.Testing do
   Returns `nil` if there are no assistant messages.
   """
   @spec last_text(State.t() | map()) :: String.t() | nil
+  def last_text(%State{} = state), do: State.last_assistant_text(state)
+
   def last_text(%{messages: messages}) do
     messages
     |> Enum.reverse()

--- a/lib/alloy/tool/executor.ex
+++ b/lib/alloy/tool/executor.ex
@@ -11,6 +11,8 @@ defmodule Alloy.Tool.Executor do
   alias Alloy.Message
   alias Alloy.Middleware
 
+  require Logger
+
   @spec execute_all([map()], %{String.t() => module()}, State.t()) ::
           Message.t() | {:halted, String.t()}
   def execute_all(tool_calls, tool_fns, %State{} = state) do
@@ -95,7 +97,13 @@ defmodule Alloy.Tool.Executor do
             end
           rescue
             e ->
+              stacktrace = __STACKTRACE__
               err = "Tool crashed: #{Exception.message(e)}"
+
+              Logger.warning(
+                "Tool #{call[:name]} crashed: #{Exception.message(e)}\n#{Exception.format_stacktrace(stacktrace)}"
+              )
+
               {block_fn.(call[:id], err, true), err, nil}
           end
 

--- a/test/alloy/result_test.exs
+++ b/test/alloy/result_test.exs
@@ -1,0 +1,103 @@
+defmodule Alloy.ResultTest do
+  use ExUnit.Case, async: true
+
+  alias Alloy.Result
+
+  describe "struct defaults" do
+    test "creates with sensible defaults" do
+      result = %Result{}
+
+      assert result.text == nil
+      assert result.messages == []
+      assert result.usage == %Alloy.Usage{}
+      assert result.tool_calls == []
+      assert result.status == :completed
+      assert result.turns == 0
+      assert result.error == nil
+      assert result.request_id == nil
+    end
+
+    test "accepts all fields" do
+      result = %Result{
+        text: "hello",
+        messages: [:msg],
+        usage: %Alloy.Usage{input_tokens: 42},
+        tool_calls: [%{name: "read"}],
+        status: :error,
+        turns: 3,
+        error: :timeout,
+        request_id: "req-abc"
+      }
+
+      assert result.text == "hello"
+      assert result.messages == [:msg]
+      assert result.usage.input_tokens == 42
+      assert result.tool_calls == [%{name: "read"}]
+      assert result.status == :error
+      assert result.turns == 3
+      assert result.error == :timeout
+      assert result.request_id == "req-abc"
+    end
+  end
+
+  describe "Access behaviour" do
+    test "bracket syntax reads fields" do
+      result = %Result{text: "hi", turns: 5}
+
+      assert result[:text] == "hi"
+      assert result[:turns] == 5
+      assert result[:error] == nil
+    end
+
+    test "get_in/2 works" do
+      result = %Result{text: "deep"}
+      assert get_in(result, [:text]) == "deep"
+    end
+
+    test "pop/2 returns value and updated struct" do
+      result = %Result{text: "gone", turns: 2}
+      {value, updated} = Access.pop(result, :text)
+
+      assert value == "gone"
+      assert updated.text == nil
+      assert updated.turns == 2
+    end
+
+    test "get_and_update/3 works" do
+      result = %Result{turns: 10}
+
+      {old, updated} =
+        Access.get_and_update(result, :turns, fn current ->
+          {current, current + 1}
+        end)
+
+      assert old == 10
+      assert updated.turns == 11
+    end
+  end
+
+  describe "backwards compatibility" do
+    test "pattern matches as a map" do
+      result = %Result{text: "match me", status: :completed}
+      assert %{text: "match me", status: :completed} = result
+    end
+
+    test "Map.get/2 works" do
+      result = %Result{text: "map-get"}
+      assert Map.get(result, :text) == "map-get"
+    end
+
+    test "Map.put/3 works" do
+      result = %Result{text: "before"}
+      updated = Map.put(result, :text, "after")
+      assert updated.text == "after"
+    end
+
+    test "Map.merge/2 works for adding extra fields" do
+      result = %Result{text: "base"}
+      merged = Map.merge(result, %{request_id: "req-123"})
+      assert merged.request_id == "req-123"
+      assert merged.text == "base"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **`Alloy.Result` struct** — typed, `Access`-compatible return value replacing duplicated plain-map construction in `Alloy.run/2` and `Server.build_result/1`. Single source of truth for the 8-field result contract. Fully backwards compatible (dot access, bracket access, pattern matching, `Map.get/put` all work).
- **OTP hardening** — `:queue` for `pending_requests` (O(1) enqueue/dequeue), async `agent_event` handler, crash logging with stacktraces across SSE/Executor/on_shutdown, `handle_info` catchall logging, `:after_tool_request` middleware hook, configurable `within_budget?/3` ratio, thinking block truncation in compactor, `server_tool_use`/`server_tool_result` token counting.
- **CHANGELOG updated** — all changes documented under `[0.7.0]` with Added, Changed, and Breaking sections.

## Test plan

- [x] New `Alloy.ResultTest` — 10 tests covering struct defaults, `Access` behaviour (bracket syntax, `get_in`, `pop`, `get_and_update`), and backwards compatibility (pattern matching, `Map.get/put/merge`)
- [x] Full test suite passes: 450 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — 0 issues
- [x] Pre-commit hooks pass (format + compile warnings-as-errors + credo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)