### PR TITLE
refactor: extract Events and Retry modules from Turn

### DIFF
--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -83,15 +83,7 @@ defmodule Alloy do
     try do
       final_state = Turn.run_loop(state)
 
-      result = %Result{
-        text: State.last_assistant_text(final_state),
-        messages: State.messages(final_state),
-        usage: final_state.usage,
-        tool_calls: final_state.tool_calls,
-        status: final_state.status,
-        turns: final_state.turn,
-        error: final_state.error
-      }
+      result = Result.from_state(final_state)
 
       case final_state.status do
         :completed -> {:ok, result}

--- a/lib/alloy/agent/events.ex
+++ b/lib/alloy/agent/events.ex
@@ -1,0 +1,133 @@
+defmodule Alloy.Agent.Events do
+  @moduledoc """
+  Event envelope construction and runtime opts normalization.
+
+  Builds v1 event envelopes, manages sequence counters, and derives
+  correlation IDs. Extracted from `Alloy.Agent.Turn` to separate
+  event plumbing from agent loop control flow.
+  """
+
+  alias Alloy.Agent.State
+
+  @doc """
+  Normalize runtime opts for event emission.
+
+  Ensures `:on_event`, `:event_seq_ref`, and `:event_correlation_id`
+  are present in the opts keyword list.
+  """
+  @spec normalize_opts(State.t(), keyword()) :: keyword()
+  def normalize_opts(%State{} = state, opts) do
+    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
+
+    opts
+    |> Keyword.put(:on_event, on_event)
+    |> put_new_lazy(:event_seq_ref, fn -> :atomics.new(1, signed: false) end)
+    |> put_new_lazy(:event_correlation_id, fn -> build_correlation_id(state) end)
+  end
+
+  @doc """
+  Derive a correlation ID from the agent state's context.
+
+  Precedence: `context[:request_id]` > `context[:correlation_id]` >
+  generated from `agent_id`.
+  """
+  @spec build_correlation_id(State.t()) :: binary()
+  def build_correlation_id(%State{} = state) do
+    context = state.config.context
+
+    cond do
+      is_binary(Map.get(context, :request_id)) ->
+        Map.get(context, :request_id)
+
+      is_binary(Map.get(context, :correlation_id)) ->
+        Map.get(context, :correlation_id)
+
+      true ->
+        state.agent_id <> ":" <> Base.url_encode64(:crypto.strong_rand_bytes(8), padding: false)
+    end
+  end
+
+  @doc """
+  Emit an event envelope.
+
+  Builds a v1 envelope from the raw event, calls the `on_event` callback,
+  and fires a `:telemetry` event.
+  """
+  @spec emit(keyword(), non_neg_integer(), term()) :: :ok
+  def emit(opts, turn, raw_event) do
+    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
+    event_seq_ref = Keyword.get(opts, :event_seq_ref)
+    correlation_id = Keyword.get(opts, :event_correlation_id)
+
+    envelope = build_event_envelope(raw_event, event_seq_ref, correlation_id, turn)
+    on_event.(envelope)
+
+    :telemetry.execute(
+      [:alloy, :event],
+      %{seq: envelope.seq},
+      %{
+        v: envelope.v,
+        event: envelope.event,
+        correlation_id: envelope.correlation_id,
+        turn: envelope.turn
+      }
+    )
+  end
+
+  # ── Private ───────────────────────────────────────────────────────────────
+
+  defp build_event_envelope(%{v: 1} = envelope, _seq_ref, _correlation_id, _turn), do: envelope
+
+  defp build_event_envelope({event, payload}, seq_ref, correlation_id, turn)
+       when is_atom(event) do
+    {seq, effective_correlation_id, normalized_payload} =
+      normalize_event_fields(event, payload, seq_ref, correlation_id)
+
+    %{
+      v: 1,
+      seq: seq,
+      correlation_id: effective_correlation_id,
+      turn: turn,
+      ts_ms: System.system_time(:millisecond),
+      event: event,
+      payload: normalized_payload
+    }
+  end
+
+  defp build_event_envelope(raw_event, seq_ref, correlation_id, turn) do
+    %{
+      v: 1,
+      seq: next_event_seq(seq_ref),
+      correlation_id: correlation_id,
+      turn: turn,
+      ts_ms: System.system_time(:millisecond),
+      event: :runtime_event,
+      payload: raw_event
+    }
+  end
+
+  defp normalize_event_fields(event, payload, seq_ref, correlation_id)
+       when event in [:tool_start, :tool_end] and is_map(payload) do
+    seq = Map.get(payload, :event_seq) || next_event_seq(seq_ref)
+    effective_correlation_id = Map.get(payload, :correlation_id) || correlation_id
+    normalized_payload = Map.drop(payload, [:event_seq, :correlation_id])
+
+    {seq, effective_correlation_id, normalized_payload}
+  end
+
+  defp normalize_event_fields(_event, payload, seq_ref, correlation_id) do
+    {next_event_seq(seq_ref), correlation_id, payload}
+  end
+
+  defp next_event_seq(ref) do
+    :atomics.add_get(ref, 1, 1)
+  end
+
+  defp put_new_lazy(opts, key, producer) when is_list(opts) and is_function(producer, 0) do
+    if Keyword.has_key?(opts, key) do
+      opts
+    else
+      Keyword.put(opts, key, producer.())
+    end
+  end
+end

--- a/lib/alloy/agent/server.ex
+++ b/lib/alloy/agent/server.ex
@@ -296,7 +296,8 @@ defmodule Alloy.Agent.Server do
       catch
         kind, reason ->
           Logger.warning(
-            "[Alloy] on_shutdown callback threw #{inspect(kind)}: #{inspect(reason)}"
+            "[Alloy] on_shutdown callback threw #{inspect(kind)}: #{inspect(reason)}\n" <>
+              "Stacktrace: #{Exception.format_stacktrace(__STACKTRACE__)}"
           )
       end
     end
@@ -686,17 +687,7 @@ defmodule Alloy.Agent.Server do
     %{state | turn: 0, status: :idle, error: nil, tool_calls: []}
   end
 
-  defp build_result(%State{} = state) do
-    %Result{
-      text: State.last_assistant_text(state),
-      messages: State.messages(state),
-      usage: state.usage,
-      tool_calls: state.tool_calls,
-      status: state.status,
-      turns: state.turn,
-      error: state.error
-    }
-  end
+  defp build_result(%State{} = state), do: Result.from_state(state)
 
   # Returns the canonical "effective session ID" used consistently for both
   # PubSub broadcast topics and the exported Session.id.

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -6,12 +6,12 @@ defmodule Alloy.Agent.Turn do
   the provider signals completion or the turn limit is reached.
 
   This is a pure function — no GenServer, no process overhead.
-  ~80 lines of actual logic.
   """
 
-  alias Alloy.Agent.State
+  alias Alloy.Agent.{Events, State}
   alias Alloy.Context.Compactor
   alias Alloy.{Message, Middleware}
+  alias Alloy.Provider.Retry
   alias Alloy.Tool.Executor
 
   # Buffer subtracted from timeout_ms when computing the retry deadline.
@@ -35,7 +35,7 @@ defmodule Alloy.Agent.Turn do
   """
   @spec run_loop(State.t(), keyword()) :: State.t()
   def run_loop(%State{} = state, opts \\ []) do
-    opts = normalize_runtime_opts(state, opts)
+    opts = Events.normalize_opts(state, opts)
 
     # Compute a hard deadline ONCE for the entire loop, leaving headroom
     # so the retry logic never overshoots the caller-side timeout.
@@ -72,7 +72,7 @@ defmodule Alloy.Agent.Turn do
         on_chunk = Keyword.get(opts, :on_chunk, fn _chunk -> :ok end)
 
         on_event = fn raw_event ->
-          emit_runtime_event(opts, provider_event_turn, raw_event)
+          Events.emit(opts, provider_event_turn, raw_event)
         end
 
         provider_config =
@@ -81,7 +81,7 @@ defmodule Alloy.Agent.Turn do
             else: provider_config
 
         result =
-          call_provider_with_retry(
+          Retry.call_with_retry(
             state,
             provider,
             provider_config,
@@ -136,7 +136,7 @@ defmodule Alloy.Agent.Turn do
 
       %State{} = state ->
         tool_calls = extract_tool_calls(new_msgs)
-        on_event = fn raw_event -> emit_runtime_event(opts, state.turn, raw_event) end
+        on_event = fn raw_event -> Events.emit(opts, state.turn, raw_event) end
         event_seq_ref = Keyword.get(opts, :event_seq_ref)
         event_correlation_id = Keyword.get(opts, :event_correlation_id)
         event_turn = state.turn
@@ -170,322 +170,11 @@ defmodule Alloy.Agent.Turn do
     end
   end
 
-  defp call_provider_with_retry(state, provider, provider_config, streaming?, on_chunk, deadline) do
-    {result, chunks_emitted?} =
-      do_provider_call(
-        state,
-        provider,
-        provider_config,
-        streaming?,
-        on_chunk,
-        state.config.max_retries,
-        deadline
-      )
-
-    case result do
-      {:ok, _} = success ->
-        success
-
-      # Once any streamed output/event was emitted, never switch providers:
-      # mixing chunks from multiple providers in one stream breaks turn semantics.
-      {:error, _reason} = error when chunks_emitted? ->
-        error
-
-      {:error, _reason} = error ->
-        try_fallback_providers(state, provider_config, streaming?, on_chunk, deadline, error)
-    end
-  end
-
-  defp try_fallback_providers(
-         state,
-         provider_config,
-         streaming?,
-         on_chunk,
-         deadline,
-         last_error
-       ) do
-    runtime_overrides = Map.take(provider_config, [:system_prompt, :on_event])
-
-    Enum.reduce_while(state.config.fallback_providers, last_error, fn
-      {fb_provider, fb_config}, acc ->
-        remaining = deadline - System.monotonic_time(:millisecond)
-
-        if remaining <= 0 do
-          {:halt, acc}
-        else
-          fb_provider_config = Map.merge(fb_config, runtime_overrides)
-
-          {result, chunks_emitted?} =
-            do_provider_call(
-              state,
-              fb_provider,
-              fb_provider_config,
-              streaming?,
-              on_chunk,
-              state.config.max_retries,
-              deadline
-            )
-
-          case result do
-            {:ok, _} = success ->
-              {:halt, success}
-
-            {:error, _} = error when chunks_emitted? ->
-              {:halt, error}
-
-            {:error, _} = error ->
-              {:cont, error}
-          end
-        end
-    end)
-  end
-
-  defp do_provider_call(
-         state,
-         provider,
-         provider_config,
-         streaming?,
-         on_chunk,
-         retries_left,
-         deadline
-       ) do
-    # Inject receive_timeout so hung HTTP requests can't overshoot the deadline.
-    # All providers read :req_options from config, so this flows through automatically.
-    provider_config = inject_receive_timeout(provider_config, deadline)
-
-    {result, chunks_emitted?} =
-      call_provider(provider, state, provider_config, streaming?, on_chunk)
-
-    case result do
-      {:ok, _} = success ->
-        {success, chunks_emitted?}
-
-      {:error, reason} when retries_left > 0 ->
-        if retryable?(reason) and not chunks_emitted? do
-          attempt = state.config.max_retries - retries_left + 1
-          base = round(state.config.retry_backoff_ms * :math.pow(2, attempt - 1))
-          # Full jitter: uniform random in [0, 2*base) — prevents thundering herd
-          # when multiple agents hit the same rate limit simultaneously.
-          backoff = :rand.uniform(base * 2)
-          remaining = deadline - System.monotonic_time(:millisecond)
-
-          if remaining < backoff do
-            # Not enough time left — return the error rather than sleeping
-            # past the GenServer.call timeout.
-            {{:error, reason}, false}
-          else
-            Process.sleep(backoff)
-
-            do_provider_call(
-              state,
-              provider,
-              provider_config,
-              streaming?,
-              on_chunk,
-              retries_left - 1,
-              deadline
-            )
-          end
-        else
-          {{:error, reason}, chunks_emitted?}
-        end
-
-      {:error, _reason} = error ->
-        {error, chunks_emitted?}
-    end
-  end
-
-  # Calls the provider and returns {result, chunks_emitted?}.
-  # For streaming calls, wraps on_chunk to detect whether any chunks were
-  # delivered before the call returned. This prevents retrying mid-stream
-  # failures that already produced partial output.
-  defp call_provider(provider, state, provider_config, true = _streaming?, on_chunk) do
-    ref = :atomics.new(1, signed: false)
-
-    original_on_event = Map.get(provider_config, :on_event, fn _ -> :ok end)
-
-    wrapped_chunk = fn chunk ->
-      :atomics.put(ref, 1, 1)
-      on_chunk.(chunk)
-      original_on_event.({:text_delta, chunk})
-    end
-
-    wrapped_on_event = fn event ->
-      :atomics.put(ref, 1, 1)
-      original_on_event.(event)
-    end
-
-    provider_config = Map.put(provider_config, :on_event, wrapped_on_event)
-
-    messages = State.messages(state)
-    result = provider.stream(messages, state.tool_defs, provider_config, wrapped_chunk)
-    {result, :atomics.get(ref, 1) == 1}
-  end
-
-  defp call_provider(provider, state, provider_config, false = _streaming?, _on_chunk) do
-    messages = State.messages(state)
-    {provider.complete(messages, state.tool_defs, provider_config), false}
-  end
-
-  # HTTP status errors — providers return strings via parse_error/2.
-  # The generic fallback format is "HTTP <status>: <body>".
-  # Retryable: 408 (request timeout), 429 (rate limit), and 5xx server errors.
-  defp retryable?("HTTP 408:" <> _), do: true
-  defp retryable?("HTTP 429:" <> _), do: true
-  defp retryable?("HTTP 500:" <> _), do: true
-  defp retryable?("HTTP 502:" <> _), do: true
-  defp retryable?("HTTP 503:" <> _), do: true
-  defp retryable?("HTTP 504:" <> _), do: true
-
-  # Anthropic-formatted rate limit errors: "rate_limit_error: ..."
-  defp retryable?("rate_limit_error:" <> _), do: true
-
-  # OpenAI-formatted rate limit errors: "rate_limit_exceeded: ..."
-  defp retryable?("rate_limit_exceeded:" <> _), do: true
-
-  # Anthropic 529 — model overloaded, always transient.
-  defp retryable?("overloaded_error:" <> _), do: true
-
-  # OpenAI 500 server error.
-  defp retryable?("server_error:" <> _), do: true
-
-  # Google Gemini — rate limited (429), internal error (500), unavailable (503).
-  defp retryable?("RESOURCE_EXHAUSTED:" <> _), do: true
-  defp retryable?("INTERNAL:" <> _), do: true
-  defp retryable?("UNAVAILABLE:" <> _), do: true
-
-  # Network-level failures from Req/Finch/Mint.
-  # Providers wrap these as: "HTTP request failed: #{inspect(reason)}"
-  # Match the bare atom name (e.g. "econnrefused") rather than the
-  # inspect-formatted version (":econnrefused") so that changes in
-  # Req/Mint struct formatting don't silently break retry matching.
-  defp retryable?("HTTP request failed: " <> rest) do
-    String.contains?(rest, "econnrefused") or
-      String.contains?(rest, "closed") or
-      String.contains?(rest, "timeout") or
-      String.contains?(rest, "unprocessed")
-  end
-
-  # Atom :timeout kept for any caller that passes atoms directly.
-  defp retryable?(:timeout), do: true
-  defp retryable?(_), do: false
-
-  # Sets receive_timeout in the provider's req_options based on remaining deadline.
-  # This prevents a single hung HTTP request from overshooting the overall timeout.
-  # Uses Keyword.put to override any user-set value — the deadline takes precedence.
-  defp inject_receive_timeout(provider_config, deadline) do
-    remaining = deadline - System.monotonic_time(:millisecond)
-    # Floor at 1s so we don't set absurdly short timeouts, but also
-    # don't overshoot the deadline when remaining time is under 5s.
-    timeout = max(remaining, 1_000)
-    existing = Map.get(provider_config, :req_options, [])
-    Map.put(provider_config, :req_options, Keyword.put(existing, :receive_timeout, timeout))
-  end
-
   defp build_provider_config(%State{config: config}) do
     Map.put(config.provider_config, :system_prompt, config.system_prompt)
   end
 
   defp extract_tool_calls(messages) do
     Enum.flat_map(messages, &Message.tool_calls/1)
-  end
-
-  defp normalize_runtime_opts(%State{} = state, opts) do
-    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
-
-    opts
-    |> Keyword.put(:on_event, on_event)
-    |> put_new_lazy(:event_seq_ref, fn -> :atomics.new(1, signed: false) end)
-    |> put_new_lazy(:event_correlation_id, fn -> build_event_correlation_id(state) end)
-  end
-
-  defp put_new_lazy(opts, key, producer) when is_list(opts) and is_function(producer, 0) do
-    if Keyword.has_key?(opts, key) do
-      opts
-    else
-      Keyword.put(opts, key, producer.())
-    end
-  end
-
-  defp build_event_correlation_id(%State{} = state) do
-    context = state.config.context
-
-    cond do
-      is_binary(Map.get(context, :request_id)) ->
-        Map.get(context, :request_id)
-
-      is_binary(Map.get(context, :correlation_id)) ->
-        Map.get(context, :correlation_id)
-
-      true ->
-        state.agent_id <> ":" <> Base.url_encode64(:crypto.strong_rand_bytes(8), padding: false)
-    end
-  end
-
-  defp emit_runtime_event(opts, turn, raw_event) do
-    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
-    event_seq_ref = Keyword.get(opts, :event_seq_ref)
-    correlation_id = Keyword.get(opts, :event_correlation_id)
-
-    envelope = build_event_envelope(raw_event, event_seq_ref, correlation_id, turn)
-    on_event.(envelope)
-
-    :telemetry.execute(
-      [:alloy, :event],
-      %{seq: envelope.seq},
-      %{
-        v: envelope.v,
-        event: envelope.event,
-        correlation_id: envelope.correlation_id,
-        turn: envelope.turn
-      }
-    )
-  end
-
-  defp build_event_envelope(%{v: 1} = envelope, _seq_ref, _correlation_id, _turn), do: envelope
-
-  defp build_event_envelope({event, payload}, seq_ref, correlation_id, turn)
-       when is_atom(event) do
-    {seq, effective_correlation_id, normalized_payload} =
-      normalize_event_fields(event, payload, seq_ref, correlation_id)
-
-    %{
-      v: 1,
-      seq: seq,
-      correlation_id: effective_correlation_id,
-      turn: turn,
-      ts_ms: System.system_time(:millisecond),
-      event: event,
-      payload: normalized_payload
-    }
-  end
-
-  defp build_event_envelope(raw_event, seq_ref, correlation_id, turn) do
-    %{
-      v: 1,
-      seq: next_event_seq(seq_ref),
-      correlation_id: correlation_id,
-      turn: turn,
-      ts_ms: System.system_time(:millisecond),
-      event: :runtime_event,
-      payload: raw_event
-    }
-  end
-
-  defp normalize_event_fields(event, payload, seq_ref, correlation_id)
-       when event in [:tool_start, :tool_end] and is_map(payload) do
-    seq = Map.get(payload, :event_seq) || next_event_seq(seq_ref)
-    effective_correlation_id = Map.get(payload, :correlation_id) || correlation_id
-    normalized_payload = Map.drop(payload, [:event_seq, :correlation_id])
-
-    {seq, effective_correlation_id, normalized_payload}
-  end
-
-  defp normalize_event_fields(_event, payload, seq_ref, correlation_id) do
-    {next_event_seq(seq_ref), correlation_id, payload}
-  end
-
-  defp next_event_seq(ref) do
-    :atomics.add_get(ref, 1, 1)
   end
 end

--- a/lib/alloy/context/compactor.ex
+++ b/lib/alloy/context/compactor.ex
@@ -68,11 +68,19 @@ defmodule Alloy.Context.Compactor do
     callback.(middle, state)
   rescue
     e ->
-      Logger.warning("on_compaction callback crashed: #{Exception.message(e)}")
+      Logger.warning(
+        "on_compaction callback crashed: #{Exception.message(e)}\n" <>
+          "Stacktrace: #{Exception.format_stacktrace(__STACKTRACE__)}"
+      )
+
       :ok
   catch
     kind, payload ->
-      Logger.warning("on_compaction callback error (#{kind}): #{inspect(payload)}")
+      Logger.warning(
+        "on_compaction callback error (#{kind}): #{inspect(payload)}\n" <>
+          "Stacktrace: #{Exception.format_stacktrace(__STACKTRACE__)}"
+      )
+
       :ok
   end
 

--- a/lib/alloy/provider/retry.ex
+++ b/lib/alloy/provider/retry.ex
@@ -1,0 +1,240 @@
+defmodule Alloy.Provider.Retry do
+  @moduledoc """
+  Provider retry, backoff, fallback, and streaming dispatch logic.
+
+  Handles exponential backoff with full jitter, retryable error
+  classification, fallback provider chains, and receive-timeout
+  injection. Extracted from `Alloy.Agent.Turn` to separate
+  provider-oriented concerns from agent loop control flow.
+  """
+
+  alias Alloy.Agent.State
+
+  @doc """
+  Call a provider with retry, backoff, and fallback logic.
+
+  Single entry point for all provider calls. Retries on transient errors
+  with exponential backoff and jitter, then falls back to configured
+  fallback providers if the primary provider fails.
+
+  Returns `{:ok, response}` or `{:error, reason}`.
+  """
+  @spec call_with_retry(State.t(), module(), map(), boolean(), function(), integer()) ::
+          {:ok, map()} | {:error, term()}
+  def call_with_retry(state, provider, provider_config, streaming?, on_chunk, deadline) do
+    {result, chunks_emitted?} =
+      do_provider_call(
+        state,
+        provider,
+        provider_config,
+        streaming?,
+        on_chunk,
+        state.config.max_retries,
+        deadline
+      )
+
+    case result do
+      {:ok, _} = success ->
+        success
+
+      # Once any streamed output/event was emitted, never switch providers:
+      # mixing chunks from multiple providers in one stream breaks turn semantics.
+      {:error, _reason} = error when chunks_emitted? ->
+        error
+
+      {:error, _reason} = error ->
+        try_fallback_providers(state, provider_config, streaming?, on_chunk, deadline, error)
+    end
+  end
+
+  @doc false
+  @spec retryable?(term()) :: boolean()
+
+  # HTTP status errors — providers return strings via parse_error/2.
+  # The generic fallback format is "HTTP <status>: <body>".
+  # Retryable: 408 (request timeout), 429 (rate limit), and 5xx server errors.
+  def retryable?("HTTP 408:" <> _), do: true
+  def retryable?("HTTP 429:" <> _), do: true
+  def retryable?("HTTP 500:" <> _), do: true
+  def retryable?("HTTP 502:" <> _), do: true
+  def retryable?("HTTP 503:" <> _), do: true
+  def retryable?("HTTP 504:" <> _), do: true
+
+  # Anthropic-formatted rate limit errors: "rate_limit_error: ..."
+  def retryable?("rate_limit_error:" <> _), do: true
+
+  # OpenAI-formatted rate limit errors: "rate_limit_exceeded: ..."
+  def retryable?("rate_limit_exceeded:" <> _), do: true
+
+  # Anthropic 529 — model overloaded, always transient.
+  def retryable?("overloaded_error:" <> _), do: true
+
+  # OpenAI 500 server error.
+  def retryable?("server_error:" <> _), do: true
+
+  # Google Gemini — rate limited (429), internal error (500), unavailable (503).
+  def retryable?("RESOURCE_EXHAUSTED:" <> _), do: true
+  def retryable?("INTERNAL:" <> _), do: true
+  def retryable?("UNAVAILABLE:" <> _), do: true
+
+  # Network-level failures from Req/Finch/Mint.
+  # Providers wrap these as: "HTTP request failed: #{inspect(reason)}"
+  # Match the bare atom name (e.g. "econnrefused") rather than the
+  # inspect-formatted version (":econnrefused") so that changes in
+  # Req/Mint struct formatting don't silently break retry matching.
+  def retryable?("HTTP request failed: " <> rest) do
+    String.contains?(rest, "econnrefused") or
+      String.contains?(rest, "closed") or
+      String.contains?(rest, "timeout") or
+      String.contains?(rest, "unprocessed")
+  end
+
+  # Atom :timeout kept for any caller that passes atoms directly.
+  def retryable?(:timeout), do: true
+  def retryable?(_), do: false
+
+  # ── Private ───────────────────────────────────────────────────────────────
+
+  defp try_fallback_providers(
+         state,
+         provider_config,
+         streaming?,
+         on_chunk,
+         deadline,
+         last_error
+       ) do
+    runtime_overrides = Map.take(provider_config, [:system_prompt, :on_event])
+
+    Enum.reduce_while(state.config.fallback_providers, last_error, fn
+      {fb_provider, fb_config}, acc ->
+        remaining = deadline - System.monotonic_time(:millisecond)
+
+        if remaining <= 0 do
+          {:halt, acc}
+        else
+          fb_provider_config = Map.merge(fb_config, runtime_overrides)
+
+          {result, chunks_emitted?} =
+            do_provider_call(
+              state,
+              fb_provider,
+              fb_provider_config,
+              streaming?,
+              on_chunk,
+              state.config.max_retries,
+              deadline
+            )
+
+          case result do
+            {:ok, _} = success ->
+              {:halt, success}
+
+            {:error, _} = error when chunks_emitted? ->
+              {:halt, error}
+
+            {:error, _} = error ->
+              {:cont, error}
+          end
+        end
+    end)
+  end
+
+  defp do_provider_call(
+         state,
+         provider,
+         provider_config,
+         streaming?,
+         on_chunk,
+         retries_left,
+         deadline
+       ) do
+    # Inject receive_timeout so hung HTTP requests can't overshoot the deadline.
+    # All providers read :req_options from config, so this flows through automatically.
+    provider_config = inject_receive_timeout(provider_config, deadline)
+
+    {result, chunks_emitted?} =
+      call_provider(provider, state, provider_config, streaming?, on_chunk)
+
+    case result do
+      {:ok, _} = success ->
+        {success, chunks_emitted?}
+
+      {:error, reason} when retries_left > 0 ->
+        if retryable?(reason) and not chunks_emitted? do
+          attempt = state.config.max_retries - retries_left + 1
+          base = round(state.config.retry_backoff_ms * :math.pow(2, attempt - 1))
+          # Full jitter: uniform random in [0, 2*base) — prevents thundering herd
+          # when multiple agents hit the same rate limit simultaneously.
+          backoff = :rand.uniform(base * 2)
+          remaining = deadline - System.monotonic_time(:millisecond)
+
+          if remaining < backoff do
+            # Not enough time left — return the error rather than sleeping
+            # past the GenServer.call timeout.
+            {{:error, reason}, false}
+          else
+            Process.sleep(backoff)
+
+            do_provider_call(
+              state,
+              provider,
+              provider_config,
+              streaming?,
+              on_chunk,
+              retries_left - 1,
+              deadline
+            )
+          end
+        else
+          {{:error, reason}, chunks_emitted?}
+        end
+
+      {:error, _reason} = error ->
+        {error, chunks_emitted?}
+    end
+  end
+
+  # Calls the provider and returns {result, chunks_emitted?}.
+  # For streaming calls, wraps on_chunk to detect whether any chunks were
+  # delivered before the call returned. This prevents retrying mid-stream
+  # failures that already produced partial output.
+  defp call_provider(provider, state, provider_config, true = _streaming?, on_chunk) do
+    ref = :atomics.new(1, signed: false)
+
+    original_on_event = Map.get(provider_config, :on_event, fn _ -> :ok end)
+
+    wrapped_chunk = fn chunk ->
+      :atomics.put(ref, 1, 1)
+      on_chunk.(chunk)
+      original_on_event.({:text_delta, chunk})
+    end
+
+    wrapped_on_event = fn event ->
+      :atomics.put(ref, 1, 1)
+      original_on_event.(event)
+    end
+
+    provider_config = Map.put(provider_config, :on_event, wrapped_on_event)
+
+    messages = State.messages(state)
+    result = provider.stream(messages, state.tool_defs, provider_config, wrapped_chunk)
+    {result, :atomics.get(ref, 1) == 1}
+  end
+
+  defp call_provider(provider, state, provider_config, false = _streaming?, _on_chunk) do
+    messages = State.messages(state)
+    {provider.complete(messages, state.tool_defs, provider_config), false}
+  end
+
+  # Sets receive_timeout in the provider's req_options based on remaining deadline.
+  # This prevents a single hung HTTP request from overshooting the overall timeout.
+  # Uses Keyword.put to override any user-set value — the deadline takes precedence.
+  defp inject_receive_timeout(provider_config, deadline) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+    # Floor at 1s so we don't set absurdly short timeouts, but also
+    # don't overshoot the deadline when remaining time is under 5s.
+    timeout = max(remaining, 1_000)
+    existing = Map.get(provider_config, :req_options, [])
+    Map.put(provider_config, :req_options, Keyword.put(existing, :receive_timeout, timeout))
+  end
+end

--- a/lib/alloy/result.ex
+++ b/lib/alloy/result.ex
@@ -44,6 +44,26 @@ defmodule Alloy.Result do
     turns: 0
   ]
 
+  @doc """
+  Build a `Result` from a final `State`.
+
+  Extracts text, messages, usage, tool calls, status, turns, and error
+  from the state. The `request_id` is left as `nil` — async callers
+  overlay it via `%{result | request_id: id}`.
+  """
+  @spec from_state(State.t()) :: t()
+  def from_state(%State{} = state) do
+    %__MODULE__{
+      text: State.last_assistant_text(state),
+      messages: State.messages(state),
+      usage: state.usage,
+      tool_calls: state.tool_calls,
+      status: state.status,
+      turns: state.turn,
+      error: state.error
+    }
+  end
+
   # ── Access callbacks ─────────────────────────────────────────────────────
 
   @impl Access

--- a/mix.exs
+++ b/mix.exs
@@ -62,6 +62,7 @@ defmodule Alloy.MixProject do
         Core: [
           Alloy,
           Alloy.Agent.Config,
+          Alloy.Agent.Events,
           Alloy.Agent.Server,
           Alloy.Agent.State,
           Alloy.Agent.Turn,
@@ -75,6 +76,7 @@ defmodule Alloy.MixProject do
           Alloy.Provider.Anthropic,
           Alloy.Provider.OpenAI,
           Alloy.Provider.OpenAICompat,
+          Alloy.Provider.Retry,
           Alloy.Provider.Test
         ],
         Tools: [

--- a/test/alloy/agent/events_test.exs
+++ b/test/alloy/agent/events_test.exs
@@ -1,0 +1,196 @@
+defmodule Alloy.Agent.EventsTest do
+  use ExUnit.Case, async: true
+
+  alias Alloy.Agent.{Config, Events, State}
+
+  defp build_state(context \\ %{}) do
+    config = %Config{
+      provider: Alloy.Provider.Test,
+      provider_config: %{},
+      context: context
+    }
+
+    State.init(config, [])
+  end
+
+  describe "normalize_opts/2" do
+    test "sets default on_event when missing" do
+      state = build_state()
+      opts = Events.normalize_opts(state, [])
+
+      assert is_function(Keyword.get(opts, :on_event), 1)
+    end
+
+    test "preserves provided on_event" do
+      state = build_state()
+      custom = fn _event -> :custom end
+      opts = Events.normalize_opts(state, on_event: custom)
+
+      assert Keyword.get(opts, :on_event) == custom
+    end
+
+    test "creates event_seq_ref atomics reference" do
+      state = build_state()
+      opts = Events.normalize_opts(state, [])
+
+      ref = Keyword.get(opts, :event_seq_ref)
+      assert is_reference(ref)
+    end
+
+    test "preserves provided event_seq_ref" do
+      state = build_state()
+      existing_ref = :atomics.new(1, signed: false)
+      opts = Events.normalize_opts(state, event_seq_ref: existing_ref)
+
+      assert Keyword.get(opts, :event_seq_ref) == existing_ref
+    end
+
+    test "creates event_correlation_id" do
+      state = build_state()
+      opts = Events.normalize_opts(state, [])
+
+      assert is_binary(Keyword.get(opts, :event_correlation_id))
+    end
+
+    test "preserves provided event_correlation_id" do
+      state = build_state()
+      opts = Events.normalize_opts(state, event_correlation_id: "my-id")
+
+      assert Keyword.get(opts, :event_correlation_id) == "my-id"
+    end
+  end
+
+  describe "build_correlation_id/1" do
+    test "uses context request_id when present" do
+      state = build_state(%{request_id: "req-123"})
+      assert Events.build_correlation_id(state) == "req-123"
+    end
+
+    test "uses context correlation_id as fallback" do
+      state = build_state(%{correlation_id: "corr-456"})
+      assert Events.build_correlation_id(state) == "corr-456"
+    end
+
+    test "prefers request_id over correlation_id" do
+      state = build_state(%{request_id: "req-123", correlation_id: "corr-456"})
+      assert Events.build_correlation_id(state) == "req-123"
+    end
+
+    test "generates agent_id-based ID when no context IDs" do
+      state = build_state()
+      id = Events.build_correlation_id(state)
+
+      assert is_binary(id)
+      assert String.starts_with?(id, state.agent_id <> ":")
+    end
+  end
+
+  describe "emit/3" do
+    test "calls on_event with v1 envelope for tuple events" do
+      test_pid = self()
+      seq_ref = :atomics.new(1, signed: false)
+
+      opts = [
+        on_event: fn envelope -> send(test_pid, {:event, envelope}) end,
+        event_seq_ref: seq_ref,
+        event_correlation_id: "test-corr"
+      ]
+
+      Events.emit(opts, 1, {:text_delta, "hello"})
+
+      assert_received {:event, envelope}
+      assert envelope.v == 1
+      assert envelope.seq == 1
+      assert envelope.correlation_id == "test-corr"
+      assert envelope.turn == 1
+      assert envelope.event == :text_delta
+      assert envelope.payload == "hello"
+      assert is_integer(envelope.ts_ms)
+    end
+
+    test "passes through pre-built v1 envelopes unchanged" do
+      test_pid = self()
+      seq_ref = :atomics.new(1, signed: false)
+
+      pre_built = %{
+        v: 1,
+        seq: 42,
+        correlation_id: "pre",
+        turn: 3,
+        ts_ms: 0,
+        event: :foo,
+        payload: :bar
+      }
+
+      opts = [
+        on_event: fn envelope -> send(test_pid, {:event, envelope}) end,
+        event_seq_ref: seq_ref,
+        event_correlation_id: "ignored"
+      ]
+
+      Events.emit(opts, 1, pre_built)
+
+      assert_received {:event, ^pre_built}
+    end
+
+    test "wraps raw (non-tuple, non-v1) events as :runtime_event" do
+      test_pid = self()
+      seq_ref = :atomics.new(1, signed: false)
+
+      opts = [
+        on_event: fn envelope -> send(test_pid, {:event, envelope}) end,
+        event_seq_ref: seq_ref,
+        event_correlation_id: "test-corr"
+      ]
+
+      Events.emit(opts, 2, "some raw string")
+
+      assert_received {:event, envelope}
+      assert envelope.event == :runtime_event
+      assert envelope.payload == "some raw string"
+      assert envelope.turn == 2
+    end
+
+    test "increments sequence numbers across calls" do
+      test_pid = self()
+      seq_ref = :atomics.new(1, signed: false)
+
+      opts = [
+        on_event: fn envelope -> send(test_pid, {:event, envelope}) end,
+        event_seq_ref: seq_ref,
+        event_correlation_id: "test-corr"
+      ]
+
+      Events.emit(opts, 1, {:a, "first"})
+      Events.emit(opts, 1, {:b, "second"})
+
+      assert_received {:event, %{seq: 1}}
+      assert_received {:event, %{seq: 2}}
+    end
+
+    test "tool_start events extract seq and correlation_id from payload" do
+      test_pid = self()
+      seq_ref = :atomics.new(1, signed: false)
+
+      opts = [
+        on_event: fn envelope -> send(test_pid, {:event, envelope}) end,
+        event_seq_ref: seq_ref,
+        event_correlation_id: "default-corr"
+      ]
+
+      Events.emit(
+        opts,
+        1,
+        {:tool_start, %{event_seq: 99, correlation_id: "tool-corr", name: "read"}}
+      )
+
+      assert_received {:event, envelope}
+      assert envelope.seq == 99
+      assert envelope.correlation_id == "tool-corr"
+      # The extracted fields should not appear in payload
+      refute Map.has_key?(envelope.payload, :event_seq)
+      refute Map.has_key?(envelope.payload, :correlation_id)
+      assert envelope.payload.name == "read"
+    end
+  end
+end

--- a/test/alloy/agent/otp_lifecycle_test.exs
+++ b/test/alloy/agent/otp_lifecycle_test.exs
@@ -114,4 +114,29 @@ defmodule Alloy.Agent.OTPLifecycleTest do
       assert session.metadata.status == :idle
     end
   end
+
+  # ── on_shutdown catch stacktrace ──────────────────────────────────────────
+
+  describe "on_shutdown catch block logs stacktrace" do
+    test "logs stacktrace when on_shutdown throws" do
+      {:ok, provider_pid} = TestProvider.start_link([TestProvider.text_response("Done")])
+
+      {:ok, agent} =
+        Server.start_link(
+          provider: {TestProvider, agent_pid: provider_pid},
+          on_shutdown: fn _session -> throw(:kaboom) end
+        )
+
+      {:ok, _} = Server.chat(agent, "Hello")
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Server.stop(agent)
+          Process.sleep(50)
+        end)
+
+      assert log =~ "on_shutdown callback threw"
+      assert log =~ "Stacktrace"
+    end
+  end
 end

--- a/test/alloy/context/compactor_test.exs
+++ b/test/alloy/context/compactor_test.exs
@@ -153,6 +153,72 @@ defmodule Alloy.Context.CompactorTest do
       compacted = Compactor.maybe_compact(state)
       assert %State{} = compacted
     end
+
+    test "logs stacktrace when on_compaction raises" do
+      callback = fn _middle, _state ->
+        raise "Boom! Callback crashed!"
+      end
+
+      big_text = String.duplicate("x", 1200)
+
+      messages = [
+        Message.user("original"),
+        Message.assistant(big_text),
+        Message.user("middle"),
+        Message.assistant("recent"),
+        Message.user("latest")
+      ]
+
+      config = %Config{
+        provider: Alloy.Provider.Test,
+        provider_config: %{},
+        max_tokens: 250,
+        on_compaction: callback
+      }
+
+      state = %State{config: config, messages: messages, messages_new: []}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Compactor.maybe_compact(state)
+        end)
+
+      assert log =~ "on_compaction callback crashed"
+      assert log =~ "Stacktrace"
+    end
+
+    test "logs stacktrace when on_compaction throws" do
+      callback = fn _middle, _state ->
+        throw(:kaboom)
+      end
+
+      big_text = String.duplicate("x", 1200)
+
+      messages = [
+        Message.user("original"),
+        Message.assistant(big_text),
+        Message.user("middle"),
+        Message.assistant("recent"),
+        Message.user("latest")
+      ]
+
+      config = %Config{
+        provider: Alloy.Provider.Test,
+        provider_config: %{},
+        max_tokens: 250,
+        on_compaction: callback
+      }
+
+      state = %State{config: config, messages: messages, messages_new: []}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Compactor.maybe_compact(state)
+        end)
+
+      assert log =~ "on_compaction callback error"
+      assert log =~ "Stacktrace"
+    end
   end
 
   describe "Config parses on_compaction" do

--- a/test/alloy/provider/retry_test.exs
+++ b/test/alloy/provider/retry_test.exs
@@ -1,0 +1,256 @@
+defmodule Alloy.Provider.RetryTest do
+  use ExUnit.Case, async: true
+
+  alias Alloy.Agent.State
+  alias Alloy.Message
+  alias Alloy.Provider.Retry
+
+  describe "retryable?/1" do
+    # HTTP status errors
+    test "408 request timeout is retryable" do
+      assert Retry.retryable?("HTTP 408: Request Timeout")
+    end
+
+    test "429 rate limit is retryable" do
+      assert Retry.retryable?("HTTP 429: Too Many Requests")
+    end
+
+    test "500 server error is retryable" do
+      assert Retry.retryable?("HTTP 500: Internal Server Error")
+    end
+
+    test "502 bad gateway is retryable" do
+      assert Retry.retryable?("HTTP 502: Bad Gateway")
+    end
+
+    test "503 service unavailable is retryable" do
+      assert Retry.retryable?("HTTP 503: Service Unavailable")
+    end
+
+    test "504 gateway timeout is retryable" do
+      assert Retry.retryable?("HTTP 504: Gateway Timeout")
+    end
+
+    test "400 bad request is not retryable" do
+      refute Retry.retryable?("HTTP 400: Bad Request")
+    end
+
+    test "401 unauthorized is not retryable" do
+      refute Retry.retryable?("HTTP 401: Unauthorized")
+    end
+
+    # Provider-specific error formats
+    test "Anthropic rate_limit_error is retryable" do
+      assert Retry.retryable?("rate_limit_error: rate limited")
+    end
+
+    test "OpenAI rate_limit_exceeded is retryable" do
+      assert Retry.retryable?("rate_limit_exceeded: quota exceeded")
+    end
+
+    test "Anthropic overloaded_error is retryable" do
+      assert Retry.retryable?("overloaded_error: model overloaded")
+    end
+
+    test "OpenAI server_error is retryable" do
+      assert Retry.retryable?("server_error: internal error")
+    end
+
+    # Google Gemini errors
+    test "Gemini RESOURCE_EXHAUSTED is retryable" do
+      assert Retry.retryable?("RESOURCE_EXHAUSTED: quota exceeded")
+    end
+
+    test "Gemini INTERNAL is retryable" do
+      assert Retry.retryable?("INTERNAL: server error")
+    end
+
+    test "Gemini UNAVAILABLE is retryable" do
+      assert Retry.retryable?("UNAVAILABLE: service down")
+    end
+
+    # Network failures
+    test "econnrefused is retryable" do
+      assert Retry.retryable?("HTTP request failed: econnrefused")
+    end
+
+    test "connection closed is retryable" do
+      assert Retry.retryable?("HTTP request failed: closed")
+    end
+
+    test "timeout in HTTP request is retryable" do
+      assert Retry.retryable?("HTTP request failed: timeout")
+    end
+
+    test "unprocessed in HTTP request is retryable" do
+      assert Retry.retryable?("HTTP request failed: unprocessed")
+    end
+
+    test "atom :timeout is retryable" do
+      assert Retry.retryable?(:timeout)
+    end
+
+    # Non-retryable
+    test "unknown string error is not retryable" do
+      refute Retry.retryable?("unknown error")
+    end
+
+    test "atom :badarg is not retryable" do
+      refute Retry.retryable?(:badarg)
+    end
+
+    test "nil is not retryable" do
+      refute Retry.retryable?(nil)
+    end
+  end
+
+  describe "call_with_retry/6" do
+    test "returns success on first try" do
+      config = retry_config()
+      state = build_state(config)
+      provider_config = %{system_prompt: nil}
+      deadline = System.monotonic_time(:millisecond) + 10_000
+
+      provider = success_provider()
+
+      result =
+        Retry.call_with_retry(state, provider, provider_config, false, fn _ -> :ok end, deadline)
+
+      assert {:ok, %{stop_reason: :end_turn}} = result
+    end
+
+    test "retries on retryable error and succeeds" do
+      config = retry_config(max_retries: 2, retry_backoff_ms: 1)
+      state = build_state(config)
+      provider_config = %{system_prompt: nil}
+      deadline = System.monotonic_time(:millisecond) + 10_000
+
+      # Use an agent to track call count
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      provider = counting_provider(counter, 1)
+
+      result =
+        Retry.call_with_retry(state, provider, provider_config, false, fn _ -> :ok end, deadline)
+
+      assert {:ok, %{stop_reason: :end_turn}} = result
+      assert Agent.get(counter, & &1) == 2
+    end
+
+    test "returns error after exhausting retries" do
+      config = retry_config(max_retries: 1, retry_backoff_ms: 1)
+      state = build_state(config)
+      provider_config = %{system_prompt: nil}
+      deadline = System.monotonic_time(:millisecond) + 10_000
+
+      provider = always_fail_provider()
+
+      result =
+        Retry.call_with_retry(state, provider, provider_config, false, fn _ -> :ok end, deadline)
+
+      assert {:error, "HTTP 500: Server Error"} = result
+    end
+
+    test "does not retry non-retryable errors" do
+      config = retry_config(max_retries: 3, retry_backoff_ms: 1)
+      state = build_state(config)
+      provider_config = %{system_prompt: nil}
+      deadline = System.monotonic_time(:millisecond) + 10_000
+
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      provider = non_retryable_fail_provider(counter)
+
+      result =
+        Retry.call_with_retry(state, provider, provider_config, false, fn _ -> :ok end, deadline)
+
+      assert {:error, "HTTP 401: Unauthorized"} = result
+      # Should only be called once (no retries)
+      assert Agent.get(counter, & &1) == 1
+    end
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────────
+
+  defp retry_config(overrides \\ []) do
+    defaults = [
+      max_retries: 3,
+      retry_backoff_ms: 1,
+      fallback_providers: []
+    ]
+
+    merged = Keyword.merge(defaults, overrides)
+
+    %Alloy.Agent.Config{
+      provider: Alloy.Provider.Test,
+      provider_config: %{},
+      max_retries: merged[:max_retries],
+      retry_backoff_ms: merged[:retry_backoff_ms],
+      fallback_providers: merged[:fallback_providers]
+    }
+  end
+
+  defp build_state(config) do
+    State.init(config, [Message.user("test")])
+  end
+
+  defp success_provider do
+    Module.create(
+      :"Elixir.Alloy.Provider.RetryTest.SuccessProvider#{System.unique_integer([:positive])}",
+      quote do
+        def complete(_messages, _tools, _config) do
+          {:ok, %{stop_reason: :end_turn, messages: [], usage: %{}}}
+        end
+      end,
+      Macro.Env.location(__ENV__)
+    )
+    |> elem(1)
+  end
+
+  defp always_fail_provider do
+    Module.create(
+      :"Elixir.Alloy.Provider.RetryTest.AlwaysFailProvider#{System.unique_integer([:positive])}",
+      quote do
+        def complete(_messages, _tools, _config) do
+          {:error, "HTTP 500: Server Error"}
+        end
+      end,
+      Macro.Env.location(__ENV__)
+    )
+    |> elem(1)
+  end
+
+  defp counting_provider(counter, fail_count) do
+    # Use Agent to track state across calls
+    Module.create(
+      :"Elixir.Alloy.Provider.RetryTest.CountingProvider#{System.unique_integer([:positive])}",
+      quote do
+        def complete(_messages, _tools, _config) do
+          count = Agent.get_and_update(unquote(counter), fn c -> {c, c + 1} end)
+
+          if count < unquote(fail_count) do
+            {:error, "HTTP 500: Server Error"}
+          else
+            {:ok, %{stop_reason: :end_turn, messages: [], usage: %{}}}
+          end
+        end
+      end,
+      Macro.Env.location(__ENV__)
+    )
+    |> elem(1)
+  end
+
+  defp non_retryable_fail_provider(counter) do
+    Module.create(
+      :"Elixir.Alloy.Provider.RetryTest.NonRetryableProvider#{System.unique_integer([:positive])}",
+      quote do
+        def complete(_messages, _tools, _config) do
+          Agent.update(unquote(counter), &(&1 + 1))
+          {:error, "HTTP 401: Unauthorized"}
+        end
+      end,
+      Macro.Env.location(__ENV__)
+    )
+    |> elem(1)
+  end
+end

--- a/test/alloy/result_test.exs
+++ b/test/alloy/result_test.exs
@@ -1,7 +1,8 @@
 defmodule Alloy.ResultTest do
   use ExUnit.Case, async: true
 
-  alias Alloy.Result
+  alias Alloy.Agent.{Config, State}
+  alias Alloy.{Message, Result, Usage}
 
   describe "struct defaults" do
     test "creates with sensible defaults" do
@@ -73,6 +74,34 @@ defmodule Alloy.ResultTest do
 
       assert old == 10
       assert updated.turns == 11
+    end
+  end
+
+  describe "from_state/1" do
+    test "builds Result from a State struct" do
+      config = %Config{
+        provider: Alloy.Provider.Test,
+        provider_config: %{}
+      }
+
+      state =
+        State.init(config, [Message.user("hello")])
+        |> State.append_messages([Message.assistant("hi there")])
+
+      state = %{state | status: :completed, turn: 2, error: nil, tool_calls: [%{name: "echo"}]}
+      state = %{state | usage: %Usage{input_tokens: 10, output_tokens: 5}}
+
+      result = Result.from_state(state)
+
+      assert %Result{} = result
+      assert result.text == "hi there"
+      assert result.status == :completed
+      assert result.turns == 2
+      assert result.error == nil
+      assert result.tool_calls == [%{name: "echo"}]
+      assert result.usage.input_tokens == 10
+      assert result.request_id == nil
+      assert length(result.messages) == 2
     end
   end
 


### PR DESCRIPTION
## Summary

- **Extract `Alloy.Agent.Events`** (133 lines) — event envelope construction, sequence counters, correlation ID derivation. Moved from `Turn` where it was unrelated to loop control flow.
- **Extract `Alloy.Provider.Retry`** (240 lines) — retry/backoff/fallback logic, retryable error classification, streaming dispatch. Provider-oriented concerns separated from agent loop.
- **Add `Result.from_state/1`** — eliminates duplicate Result construction in `Alloy.run/2` and `Server.build_result/1`.
- **Fix `__STACKTRACE__` in catch blocks** — `server.ex` and `compactor.ex` now log stacktraces in catch blocks for better debugging.
- **Update `mix.exs` docs groups** — new modules added to hex docs sidebar.

`Turn.run_loop/2` public API is **unchanged** — all callers (Server, Testing, `Alloy.run`) are unaffected.

| Metric | Before | After |
|--------|--------|-------|
| `turn.ex` lines | 492 | **180** |
| Total tests | 450 | **496** (+46 new) |
| Credo issues | 0 | **0** |
| New dialyzer warnings | — | **0** |

## Test plan

- [x] 46 new unit tests covering Events, Retry, Result.from_state, and stacktrace logging
- [x] All 496 tests pass
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` — 0 issues
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix dialyzer` — no new warnings (5 pre-existing opaque type warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)