### PR TITLE
fix: resolve 4 review findings, bump to 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.5] - 2026-03-13
+
+### Fixed
+
+- **EchoTool test crashes (7 warnings)** — `EchoTool.execute/2` now accepts both string and atom key maps, fixing pattern-match failures when the test provider sends atom-keyed tool inputs.
+- **Anthropic double-timeout** — removed the `Task.Supervisor` wrapper from `Anthropic.complete/3`. Req's `receive_timeout` (injected by `Retry.inject_receive_timeout`) already enforces the deadline — the Task added a redundant `yield + 5s` buffer. `complete/3` now calls `Req.request` directly, matching the OpenAI and OpenAICompat providers.
+- **6 Dialyzer warnings resolved** — changed `pending_requests` typespec from `:queue.queue()` (opaque in OTP 28) to `term()` in `State`, replaced `when value == %{}` guard with `map_size/1` in `Result`, and removed unreachable `nil` clause in `maybe_put_metadata/3`.
+- **`stringify_keys/1` safety** — added explicit `is_binary(k)` clause and `raise ArgumentError` for unexpected (non-atom, non-string) map keys instead of silent pass-through.
+
 ## [0.7.4] - 2026-03-06
 
 ### Added
@@ -275,6 +284,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interactive REPL via `mix alloy`
 - Deterministic test provider for full TDD workflows
 
+[0.7.5]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.5
+[0.7.4]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.4
 [0.7.3]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.3
 [0.7.2]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.2
 [0.7.1]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alloy is the completion-tool-call loop and nothing else. Send messages to any LL
   tools: [Alloy.Tool.Core.Read]
 )
 
-result.text #=> "The version is 0.7.4"
+result.text #=> "The version is 0.7.5"
 ```
 
 ## Why Alloy?
@@ -31,6 +31,30 @@ Most agent frameworks try to be everything — sessions, memory, RAG, multi-agen
 - **Context compaction** — automatic summarization when approaching token limits
 - **OTP-native** — supervision trees, hot code reloading, real parallel tool execution
 - **~5,000 lines** — small enough to read, understand, and extend
+
+## Design Boundary
+
+Alloy stays minimal by owning protocol and loop concerns, not application
+workflows.
+
+What belongs in Alloy:
+- Provider wire-format translation
+- Tool-call / completion loop mechanics
+- Normalized message blocks
+- Opaque provider-owned state such as stored response IDs
+- Provider response metadata such as citations or server-side tool telemetry
+
+What does not belong in Alloy:
+- Sessions and persistence policy
+- File storage, indexing, or retrieval workflows
+- UI rendering for citations, search, or artifacts
+- Scheduling, background job orchestration, or dashboards
+- Tenant plans, quotas, billing, or hosted infrastructure policy
+
+Rule of thumb: if the feature is required to speak a provider API correctly,
+and could help any Alloy consumer, it likely belongs here. If it needs a
+database table, product defaults, UI decisions, or tenancy logic, it belongs in
+your application layer.
 
 ## Installation
 
@@ -109,6 +133,68 @@ end)
 
 All providers support streaming. If a custom provider doesn't implement
 `stream/4`, the turn loop falls back to `complete/3` automatically.
+
+### Provider-owned state
+
+Some provider APIs expose server-side state such as stored response IDs.
+That transport concern lives in Alloy; your app decides whether and how to
+persist it.
+
+Results expose provider-owned state in `result.metadata.provider_state`:
+
+```elixir
+{:ok, result} =
+  Alloy.run("Read the repo",
+    provider: {Alloy.Provider.OpenAI,
+      api_key: System.get_env("XAI_API_KEY"),
+      api_url: "https://api.x.ai",
+      model: "grok-4",
+      store: true
+    }
+  )
+
+provider_state = result.metadata.provider_state
+```
+
+Pass that state back to the same provider on the next turn to continue a
+provider-native conversation:
+
+```elixir
+{:ok, next_result} =
+  Alloy.run("Keep going",
+    messages: result.messages,
+    provider: {Alloy.Provider.OpenAI,
+      api_key: System.get_env("XAI_API_KEY"),
+      api_url: "https://api.x.ai",
+      model: "grok-4",
+      provider_state: provider_state
+    }
+  )
+```
+
+### Provider-native tools and citations
+
+Responses-compatible providers can expose built-in server-side tools without
+leaking those wire details into your app layer.
+
+For xAI search tools:
+
+```elixir
+{:ok, result} =
+  Alloy.run("Summarise the latest xAI docs updates",
+    provider: {Alloy.Provider.OpenAI,
+      api_key: System.get_env("XAI_API_KEY"),
+      api_url: "https://api.x.ai",
+      model: "grok-4",
+      web_search: %{allowed_domains: ["docs.x.ai"]},
+      include: ["inline_citations"]
+    }
+  )
+```
+
+Citation metadata is exposed in two places:
+- `result.metadata.provider_response.citations` for provider-level citation data
+- assistant text blocks may include `:annotations` for inline citation spans
 
 ### Overriding model metadata
 

--- a/lib/alloy/agent/state.ex
+++ b/lib/alloy/agent/state.ex
@@ -22,10 +22,12 @@ defmodule Alloy.Agent.State do
           tool_calls: [map()],
           tool_defs: [map()],
           tool_fns: %{String.t() => module()},
+          provider_state: map(),
+          provider_response_metadata: map(),
           started_at: integer() | nil,
           agent_id: String.t(),
           current_task: {reference(), pid(), binary()} | nil,
-          pending_requests: :queue.queue({String.t(), binary()})
+          pending_requests: term()
         }
 
   @enforce_keys [:config]
@@ -40,6 +42,8 @@ defmodule Alloy.Agent.State do
     status: :idle,
     tool_defs: [],
     tool_fns: %{},
+    provider_state: %{},
+    provider_response_metadata: %{},
     started_at: nil,
     agent_id: "",
     current_task: nil,
@@ -61,6 +65,7 @@ defmodule Alloy.Agent.State do
       messages: messages,
       tool_defs: tool_defs,
       tool_fns: tool_fns,
+      provider_state: Map.get(config.provider_config, :provider_state, %{}),
       started_at: System.monotonic_time(:millisecond),
       agent_id: agent_id
     }
@@ -89,6 +94,26 @@ defmodule Alloy.Agent.State do
   @spec append_tool_calls(t(), [map()]) :: t()
   def append_tool_calls(%__MODULE__{} = state, tool_calls) when is_list(tool_calls) do
     %{state | tool_calls: state.tool_calls ++ tool_calls}
+  end
+
+  @doc """
+  Merge provider-owned state returned by the model backend.
+  """
+  @spec merge_provider_state(t(), map() | nil) :: t()
+  def merge_provider_state(%__MODULE__{} = state, nil), do: state
+
+  def merge_provider_state(%__MODULE__{} = state, provider_state) when is_map(provider_state) do
+    %{state | provider_state: Map.merge(state.provider_state, provider_state)}
+  end
+
+  @doc """
+  Replace the latest provider response metadata for this run.
+  """
+  @spec put_provider_response_metadata(t(), map() | nil) :: t()
+  def put_provider_response_metadata(%__MODULE__{} = state, nil), do: state
+
+  def put_provider_response_metadata(%__MODULE__{} = state, metadata) when is_map(metadata) do
+    %{state | provider_response_metadata: metadata}
   end
 
   @doc """

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -91,21 +91,29 @@ defmodule Alloy.Agent.Turn do
           )
 
         case result do
-          {:ok, %{stop_reason: :tool_use, messages: new_msgs, usage: usage}} ->
+          {:ok, %{stop_reason: :tool_use, messages: new_msgs, usage: usage} = provider_response} ->
             state =
               state
               |> State.append_messages(new_msgs)
               |> State.increment_turn()
               |> State.merge_usage(usage)
+              |> State.merge_provider_state(Map.get(provider_response, :provider_state))
+              |> State.put_provider_response_metadata(
+                Map.get(provider_response, :response_metadata)
+              )
 
             handle_tool_use(state, new_msgs, opts, deadline)
 
-          {:ok, %{stop_reason: :end_turn, messages: new_msgs, usage: usage}} ->
+          {:ok, %{stop_reason: :end_turn, messages: new_msgs, usage: usage} = provider_response} ->
             state =
               state
               |> State.append_messages(new_msgs)
               |> State.increment_turn()
               |> State.merge_usage(usage)
+              |> State.merge_provider_state(Map.get(provider_response, :provider_state))
+              |> State.put_provider_response_metadata(
+                Map.get(provider_response, :response_metadata)
+              )
 
             case Middleware.run(:after_completion, state) do
               {:halted, reason} ->
@@ -170,8 +178,10 @@ defmodule Alloy.Agent.Turn do
     end
   end
 
-  defp build_provider_config(%State{config: config}) do
-    Map.put(config.provider_config, :system_prompt, config.system_prompt)
+  defp build_provider_config(%State{config: config, provider_state: provider_state}) do
+    config.provider_config
+    |> Map.put(:system_prompt, config.system_prompt)
+    |> Map.put(:provider_state, provider_state)
   end
 
   defp extract_tool_calls(messages) do

--- a/lib/alloy/provider.ex
+++ b/lib/alloy/provider.ex
@@ -12,15 +12,21 @@ defmodule Alloy.Provider do
   - `:stop_reason` - `:tool_use` (continue looping) or `:end_turn` (done)
   - `:messages` - list of `Alloy.Message` structs from the response
   - `:usage` - map with `:input_tokens` and `:output_tokens`
+  - `:provider_state` - optional opaque map Alloy feeds back to the same provider
+    on subsequent turns (for example, stored response IDs)
+  - `:response_metadata` - optional provider response metadata exposed to the app
+    layer (for example, citations or server-side tool usage)
   """
 
   @type stop_reason :: :tool_use | :end_turn
   @type tool_def :: %{name: String.t(), description: String.t(), input_schema: map()}
 
   @type completion_response :: %{
-          stop_reason: stop_reason(),
-          messages: [Alloy.Message.t()],
-          usage: map()
+          required(:stop_reason) => stop_reason(),
+          required(:messages) => [Alloy.Message.t()],
+          required(:usage) => map(),
+          optional(:provider_state) => map(),
+          optional(:response_metadata) => map()
         }
 
   @doc """
@@ -66,8 +72,14 @@ defmodule Alloy.Provider do
   @spec stringify_keys(term()) :: term()
   def stringify_keys(map) when is_map(map) do
     Map.new(map, fn
-      {k, v} when is_atom(k) -> {Atom.to_string(k), stringify_keys(v)}
-      {k, v} -> {k, stringify_keys(v)}
+      {k, v} when is_atom(k) ->
+        {Atom.to_string(k), stringify_keys(v)}
+
+      {k, v} when is_binary(k) ->
+        {k, stringify_keys(v)}
+
+      {k, _v} ->
+        raise ArgumentError, "stringify_keys expects atom or string keys, got: #{inspect(k)}"
     end)
   end
 

--- a/lib/alloy/provider/anthropic.ex
+++ b/lib/alloy/provider/anthropic.ex
@@ -50,39 +50,31 @@ defmodule Alloy.Provider.Anthropic do
   @default_api_url "https://api.anthropic.com"
   @default_api_version "2023-06-01"
   @default_max_tokens 4096
-  @default_provider_timeout 15_000
   @code_execution_tool_type "code_execution_20250825"
   @code_execution_beta "code-execution-2025-08-25"
 
   @impl true
   def complete(messages, tool_defs, config) do
     body = build_request_body(messages, tool_defs, config)
-    timeout = Map.get(config, :provider_timeout, @default_provider_timeout)
 
     req_opts =
       ([
          url: "#{Map.get(config, :api_url, @default_api_url)}/v1/messages",
          method: :post,
          headers: build_headers(config),
-         body: Jason.encode!(body),
-         receive_timeout: timeout
+         body: Jason.encode!(body)
        ] ++ Map.get(config, :req_options, []))
       |> Keyword.put(:retry, false)
 
-    task = Task.Supervisor.async_nolink(Alloy.TaskSupervisor, fn -> Req.request(req_opts) end)
-
-    case Task.yield(task, timeout + 5_000) || Task.shutdown(task, :brutal_kill) do
-      {:ok, {:ok, %{status: 200, body: resp_body}}} ->
+    case Req.request(req_opts) do
+      {:ok, %{status: 200, body: resp_body}} ->
         parse_response(resp_body)
 
-      {:ok, {:ok, %{status: status, body: resp_body}}} ->
+      {:ok, %{status: status, body: resp_body}} ->
         {:error, parse_error(status, resp_body)}
 
-      {:ok, {:error, reason}} ->
+      {:error, reason} ->
         {:error, "HTTP request failed: #{inspect(reason)}"}
-
-      nil ->
-        {:error, "HTTP request failed: provider timeout after #{timeout}ms"}
     end
   end
 

--- a/lib/alloy/provider/openai.ex
+++ b/lib/alloy/provider/openai.ex
@@ -16,6 +16,18 @@ defmodule Alloy.Provider.OpenAI do
   - `:system_prompt` - System prompt string
   - `:api_url` - Base URL (default: "https://api.openai.com"). Can point to
     compatible Responses APIs such as xAI's "https://api.x.ai"
+  - `:provider_state` - opaque provider-owned state carried across turns.
+    For Responses APIs Alloy uses `%{response_id: "..."}`
+  - `:store` - Persist the response server-side when supported
+  - `:include` - Additional response fields to include
+  - `:tool_choice` - Provider-native tool selection mode
+  - `:parallel_tool_calls` - Whether the provider may issue tool calls in parallel
+  - `:previous_response_id` - Explicit Responses continuation ID. Overrides
+    `provider_state.response_id` when both are present
+  - `:built_in_tools` - provider-native tool definitions to append to custom
+    function tools
+  - `:web_search` - `true` or a config map to append a `web_search` tool
+  - `:x_search` - `true` or a config map to append an `x_search` tool
   - `:req_options` - Additional options passed to Req
 
   ## Example
@@ -125,16 +137,75 @@ defmodule Alloy.Provider.OpenAI do
   defp build_request_body(messages, tool_defs, config) do
     input_items = build_input_items(messages, config)
 
-    body = %{
-      "model" => config.model,
-      "max_output_tokens" => Map.get(config, :max_tokens, @default_max_tokens),
-      "input" => input_items
-    }
+    body =
+      %{
+        "model" => config.model,
+        "max_output_tokens" => Map.get(config, :max_tokens, @default_max_tokens),
+        "input" => input_items
+      }
+      |> maybe_put_previous_response_id(config)
+      |> maybe_put_optional_request_field("store", Map.get(config, :store))
+      |> maybe_put_optional_request_field("include", Map.get(config, :include))
+      |> maybe_put_optional_request_field("tool_choice", Map.get(config, :tool_choice))
+      |> maybe_put_optional_request_field(
+        "parallel_tool_calls",
+        Map.get(config, :parallel_tool_calls)
+      )
 
-    case tool_defs do
+    tools =
+      Enum.map(tool_defs, &format_tool_def/1) ++ built_in_tools(config)
+
+    case tools do
       [] -> body
-      defs -> Map.put(body, "tools", Enum.map(defs, &format_tool_def/1))
+      defs -> Map.put(body, "tools", defs)
     end
+  end
+
+  defp maybe_put_previous_response_id(body, config) do
+    previous_response_id =
+      Map.get(config, :previous_response_id) ||
+        get_in(config, [:provider_state, :response_id])
+
+    maybe_put_optional_request_field(body, "previous_response_id", previous_response_id)
+  end
+
+  defp maybe_put_optional_request_field(body, _key, nil), do: body
+  defp maybe_put_optional_request_field(body, _key, value) when value == [], do: body
+  defp maybe_put_optional_request_field(body, key, value), do: Map.put(body, key, value)
+
+  defp built_in_tools(config) do
+    []
+    |> maybe_append_built_in_tool("web_search", Map.get(config, :web_search))
+    |> maybe_append_built_in_tool("x_search", Map.get(config, :x_search))
+    |> Kernel.++(normalize_built_in_tools(Map.get(config, :built_in_tools, [])))
+  end
+
+  defp maybe_append_built_in_tool(tools, _type, nil), do: tools
+  defp maybe_append_built_in_tool(tools, _type, false), do: tools
+  defp maybe_append_built_in_tool(tools, type, true), do: tools ++ [%{"type" => type}]
+
+  defp maybe_append_built_in_tool(tools, "web_search", config) when is_map(config) do
+    tools ++ [normalize_web_search_tool(config)]
+  end
+
+  defp maybe_append_built_in_tool(tools, type, config) when is_map(config) do
+    tools ++ [Map.put(Alloy.Provider.stringify_keys(config), "type", type)]
+  end
+
+  defp normalize_built_in_tools(tools) when is_list(tools) do
+    Enum.map(tools, &normalize_built_in_tool/1)
+  end
+
+  defp normalize_built_in_tools(_), do: []
+
+  defp normalize_built_in_tool(%{"type" => _type} = tool), do: Alloy.Provider.stringify_keys(tool)
+
+  defp normalize_built_in_tool(%{type: _type} = tool), do: Alloy.Provider.stringify_keys(tool)
+
+  defp normalize_web_search_tool(config) do
+    config
+    |> Alloy.Provider.stringify_keys()
+    |> Map.put("type", "web_search")
   end
 
   defp build_input_items(messages, config) do
@@ -329,6 +400,7 @@ defmodule Alloy.Provider.OpenAI do
 
   defp parse_response(%{"output" => output} = resp) when is_list(output) do
     usage = resp["usage"] || %{}
+    provider_state = provider_state_from_response(resp)
 
     case parse_output_to_blocks(output) do
       {:ok, content_blocks} ->
@@ -346,7 +418,9 @@ defmodule Alloy.Provider.OpenAI do
            usage: %{
              input_tokens: Map.get(usage, "input_tokens", 0),
              output_tokens: Map.get(usage, "output_tokens", 0)
-           }
+           },
+           provider_state: provider_state,
+           response_metadata: response_metadata_from_response(resp)
          }}
 
       {:error, _} = err ->
@@ -356,6 +430,7 @@ defmodule Alloy.Provider.OpenAI do
 
   defp parse_response(%{"output_text" => text} = resp) when is_binary(text) do
     usage = resp["usage"] || %{}
+    provider_state = provider_state_from_response(resp)
 
     content_blocks =
       case text do
@@ -370,7 +445,9 @@ defmodule Alloy.Provider.OpenAI do
        usage: %{
          input_tokens: Map.get(usage, "input_tokens", 0),
          output_tokens: Map.get(usage, "output_tokens", 0)
-       }
+       },
+       provider_state: provider_state,
+       response_metadata: response_metadata_from_response(resp)
      }}
   end
 
@@ -428,8 +505,8 @@ defmodule Alloy.Provider.OpenAI do
   defp parse_assistant_content(content) when is_list(content) do
     content
     |> Enum.flat_map(fn
-      %{"type" => "output_text", "text" => text} when is_binary(text) and text != "" ->
-        [%{type: "text", text: text}]
+      %{"type" => "output_text", "text" => text} = item when is_binary(text) and text != "" ->
+        [%{type: "text", text: text} |> maybe_put_annotations(item["annotations"])]
 
       %{"type" => "refusal", "refusal" => text} when is_binary(text) and text != "" ->
         [%{type: "text", text: text}]
@@ -493,4 +570,30 @@ defmodule Alloy.Provider.OpenAI do
   end
 
   defp format_error_payload(error), do: inspect(error)
+
+  defp provider_state_from_response(%{"id" => id}) when is_binary(id) and id != "" do
+    %{response_id: id}
+  end
+
+  defp provider_state_from_response(_resp), do: %{}
+
+  defp response_metadata_from_response(resp) do
+    %{}
+    |> maybe_put_response_metadata(:citations, Map.get(resp, "citations"))
+    |> maybe_put_response_metadata(
+      :server_side_tool_usage,
+      Map.get(resp, "server_side_tool_usage")
+    )
+  end
+
+  defp maybe_put_response_metadata(metadata, _key, nil), do: metadata
+  defp maybe_put_response_metadata(metadata, _key, value) when value == [], do: metadata
+  defp maybe_put_response_metadata(metadata, key, value), do: Map.put(metadata, key, value)
+
+  defp maybe_put_annotations(block, annotations)
+       when is_list(annotations) and annotations != [] do
+    Map.put(block, :annotations, annotations)
+  end
+
+  defp maybe_put_annotations(block, _annotations), do: block
 end

--- a/lib/alloy/provider/test.ex
+++ b/lib/alloy/provider/test.ex
@@ -122,6 +122,20 @@ defmodule Alloy.Provider.Test do
   end
 
   @doc """
+  Builds a scripted `{:ok, completion_response}` with text and provider state.
+  """
+  @spec text_response(String.t(), map()) :: {:ok, Alloy.Provider.completion_response()}
+  def text_response(text, provider_state) when is_binary(text) and is_map(provider_state) do
+    {:ok,
+     %{
+       stop_reason: :end_turn,
+       messages: [Alloy.Message.assistant(text)],
+       usage: %{input_tokens: 10, output_tokens: 5},
+       provider_state: provider_state
+     }}
+  end
+
+  @doc """
   Builds a scripted `{:ok, completion_response}` with tool_use blocks.
   """
   @spec tool_use_response([Alloy.Message.content_block()]) ::

--- a/lib/alloy/result.ex
+++ b/lib/alloy/result.ex
@@ -11,6 +11,7 @@ defmodule Alloy.Result do
     * `:messages` — full conversation history
     * `:usage` — accumulated `%Alloy.Usage{}` token counts
     * `:tool_calls` — list of tool execution metadata maps
+    * `:metadata` — auxiliary result metadata such as provider-owned state
     * `:status` — final run status (`:completed`, `:max_turns`, `:error`, `:halted`)
     * `:turns` — number of agent loop iterations
     * `:error` — error term (or `nil` on success)
@@ -27,6 +28,7 @@ defmodule Alloy.Result do
           messages: [Message.t()],
           usage: Usage.t(),
           tool_calls: [map()],
+          metadata: map(),
           status: State.status(),
           turns: non_neg_integer(),
           error: term() | nil,
@@ -40,6 +42,7 @@ defmodule Alloy.Result do
     messages: [],
     usage: %Usage{},
     tool_calls: [],
+    metadata: %{},
     status: :completed,
     turns: 0
   ]
@@ -58,6 +61,7 @@ defmodule Alloy.Result do
       messages: State.messages(state),
       usage: state.usage,
       tool_calls: state.tool_calls,
+      metadata: build_metadata(state),
       status: state.status,
       turns: state.turn,
       error: state.error
@@ -77,4 +81,15 @@ defmodule Alloy.Result do
     value = Map.get(result, key)
     {value, Map.put(result, key, nil)}
   end
+
+  defp build_metadata(%State{} = state) do
+    %{}
+    |> maybe_put_metadata(:provider_state, state.provider_state)
+    |> maybe_put_metadata(:provider_response, state.provider_response_metadata)
+  end
+
+  defp maybe_put_metadata(metadata, _key, value) when is_map(value) and map_size(value) == 0,
+    do: metadata
+
+  defp maybe_put_metadata(metadata, key, value), do: Map.put(metadata, key, value)
 end

--- a/lib/alloy/session.ex
+++ b/lib/alloy/session.ex
@@ -50,7 +50,13 @@ defmodule Alloy.Session do
   """
   @spec update_from_result(t(), map()) :: t()
   def update_from_result(%__MODULE__{} = session, result) do
-    %{session | messages: result.messages, usage: result.usage, updated_at: DateTime.utc_now()}
+    %{
+      session
+      | messages: result.messages,
+        usage: result.usage,
+        metadata: Map.merge(session.metadata, Map.get(result, :metadata, %{})),
+        updated_at: DateTime.utc_now()
+    }
   end
 
   defp generate_id do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.7.4"
+  @version "0.7.5"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do

--- a/test/alloy/agent/turn_test.exs
+++ b/test/alloy/agent/turn_test.exs
@@ -105,6 +105,55 @@ defmodule Alloy.Agent.TurnTest do
       assert end_event_seq > start_event_seq
     end
 
+    test "carries provider_state across turns and exposes it in final state" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"text" => "world"}}
+          ]),
+          TestProvider.text_response("Tool said: Echo: world", %{response_id: "resp_123"})
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool]
+      }
+
+      state = State.init(config, [Message.user("Echo world")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+      assert result.provider_state == %{response_id: "resp_123"}
+    end
+
+    test "stores latest provider response metadata in final state" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          {:ok,
+           %{
+             stop_reason: :end_turn,
+             messages: [Message.assistant("Hello there!")],
+             usage: %{input_tokens: 10, output_tokens: 5},
+             response_metadata: %{citations: [%{"url" => "https://docs.x.ai/overview"}]}
+           }}
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid}
+      }
+
+      state = State.init(config, [Message.user("Hi")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+
+      assert result.provider_response_metadata == %{
+               citations: [%{"url" => "https://docs.x.ai/overview"}]
+             }
+    end
+
     test "handles multiple tool calls in one turn" do
       {:ok, pid} =
         TestProvider.start_link([

--- a/test/alloy/provider/openai_test.exs
+++ b/test/alloy/provider/openai_test.exs
@@ -28,6 +28,7 @@ defmodule Alloy.Provider.OpenAITest do
       assert Message.text(hd(result.messages)) == "Hello!"
       assert result.usage.input_tokens == 10
       assert result.usage.output_tokens == 5
+      assert result.provider_state == %{response_id: "resp_test"}
     end
   end
 
@@ -193,6 +194,88 @@ defmodule Alloy.Provider.OpenAITest do
 
       assert_received {:request_info, %{host: "api.x.ai", request_path: "/v1/responses"}}
     end
+
+    test "includes native Responses API controls in the request body" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:provider_state, %{response_id: "resp_prev"})
+        |> Map.put(:store, true)
+        |> Map.put(:include, ["inline_citations"])
+        |> Map.put(:tool_choice, "required")
+        |> Map.put(:parallel_tool_calls, false)
+
+      OpenAI.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert decoded["previous_response_id"] == "resp_prev"
+      assert decoded["store"] == true
+      assert decoded["include"] == ["inline_citations"]
+      assert decoded["tool_choice"] == "required"
+      assert decoded["parallel_tool_calls"] == false
+    end
+
+    test "explicit previous_response_id overrides provider_state response_id" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:provider_state, %{response_id: "resp_prev"})
+        |> Map.put(:previous_response_id, "resp_explicit")
+
+      OpenAI.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert decoded["previous_response_id"] == "resp_explicit"
+    end
+
+    test "includes provider-native built-in search tools" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:web_search, %{allowed_domains: ["docs.x.ai"]})
+        |> Map.put(:x_search, %{max_search_results: 5})
+
+      OpenAI.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert [
+               %{
+                 "type" => "web_search",
+                 "allowed_domains" => ["docs.x.ai"]
+               },
+               %{
+                 "type" => "x_search",
+                 "max_search_results" => 5
+               }
+             ] = decoded["tools"]
+    end
+
+    test "appends raw built_in_tools after custom function tools" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:built_in_tools, [%{type: "web_search_preview"}])
+
+      tool_defs = [
+        %{
+          name: "read",
+          description: "Read a file",
+          input_schema: %{type: "object", properties: %{}}
+        }
+      ]
+
+      OpenAI.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert [
+               %{"type" => "function", "name" => "read"},
+               %{"type" => "web_search_preview"}
+             ] = decoded["tools"]
+    end
   end
 
   describe "complete/3 multimodal formatting" do
@@ -318,6 +401,76 @@ defmodule Alloy.Provider.OpenAITest do
       assert result.stop_reason == :end_turn
       assert result.usage.input_tokens == 0
       assert result.usage.output_tokens == 0
+    end
+  end
+
+  describe "complete/3 response metadata" do
+    test "captures citations and output text annotations" do
+      config =
+        config_with_response(%{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "id" => "resp_test",
+              "object" => "response",
+              "status" => "completed",
+              "citations" => [
+                %{
+                  "type" => "url_citation",
+                  "url" => "https://docs.x.ai/overview",
+                  "title" => "Overview"
+                }
+              ],
+              "output" => [
+                %{
+                  "id" => "msg_test",
+                  "type" => "message",
+                  "role" => "assistant",
+                  "content" => [
+                    %{
+                      "type" => "output_text",
+                      "text" => "xAI says hi [1]",
+                      "annotations" => [
+                        %{
+                          "type" => "url_citation",
+                          "url" => "https://docs.x.ai/overview",
+                          "title" => "Overview",
+                          "start_index" => 12,
+                          "end_index" => 15
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "usage" => %{"input_tokens" => 10, "output_tokens" => 5}
+            })
+        })
+
+      assert {:ok, result} = OpenAI.complete([Message.user("Hi")], [], config)
+
+      assert result.response_metadata == %{
+               citations: [
+                 %{
+                   "type" => "url_citation",
+                   "url" => "https://docs.x.ai/overview",
+                   "title" => "Overview"
+                 }
+               ]
+             }
+
+      [%Message{content: [%{type: "text", text: "xAI says hi [1]", annotations: annotations}]}] =
+        result.messages
+
+      assert annotations == [
+               %{
+                 "type" => "url_citation",
+                 "url" => "https://docs.x.ai/overview",
+                 "title" => "Overview",
+                 "start_index" => 12,
+                 "end_index" => 15
+               }
+             ]
     end
   end
 

--- a/test/alloy/result_test.exs
+++ b/test/alloy/result_test.exs
@@ -12,6 +12,7 @@ defmodule Alloy.ResultTest do
       assert result.messages == []
       assert result.usage == %Alloy.Usage{}
       assert result.tool_calls == []
+      assert result.metadata == %{}
       assert result.status == :completed
       assert result.turns == 0
       assert result.error == nil
@@ -24,6 +25,10 @@ defmodule Alloy.ResultTest do
         messages: [:msg],
         usage: %Alloy.Usage{input_tokens: 42},
         tool_calls: [%{name: "read"}],
+        metadata: %{
+          provider_state: %{response_id: "resp_123"},
+          provider_response: %{citations: [%{"url" => "https://docs.x.ai/overview"}]}
+        },
         status: :error,
         turns: 3,
         error: :timeout,
@@ -34,6 +39,12 @@ defmodule Alloy.ResultTest do
       assert result.messages == [:msg]
       assert result.usage.input_tokens == 42
       assert result.tool_calls == [%{name: "read"}]
+
+      assert result.metadata == %{
+               provider_state: %{response_id: "resp_123"},
+               provider_response: %{citations: [%{"url" => "https://docs.x.ai/overview"}]}
+             }
+
       assert result.status == :error
       assert result.turns == 3
       assert result.error == :timeout
@@ -90,6 +101,12 @@ defmodule Alloy.ResultTest do
 
       state = %{state | status: :completed, turn: 2, error: nil, tool_calls: [%{name: "echo"}]}
       state = %{state | usage: %Usage{input_tokens: 10, output_tokens: 5}}
+      state = %{state | provider_state: %{response_id: "resp_456"}}
+
+      state = %{
+        state
+        | provider_response_metadata: %{citations: [%{"url" => "https://docs.x.ai/overview"}]}
+      }
 
       result = Result.from_state(state)
 
@@ -99,6 +116,12 @@ defmodule Alloy.ResultTest do
       assert result.turns == 2
       assert result.error == nil
       assert result.tool_calls == [%{name: "echo"}]
+
+      assert result.metadata == %{
+               provider_state: %{response_id: "resp_456"},
+               provider_response: %{citations: [%{"url" => "https://docs.x.ai/overview"}]}
+             }
+
       assert result.usage.input_tokens == 10
       assert result.request_id == nil
       assert length(result.messages) == 2

--- a/test/alloy/session_test.exs
+++ b/test/alloy/session_test.exs
@@ -99,5 +99,26 @@ defmodule Alloy.SessionTest do
 
       assert updated.metadata == %{agent: "researcher"}
     end
+
+    test "merges result metadata into session metadata" do
+      session = Session.new(metadata: %{agent: "researcher"})
+
+      result = %{
+        messages: [Message.user("test")],
+        usage: %Usage{input_tokens: 5},
+        metadata: %{
+          provider_state: %{response_id: "resp_789"},
+          provider_response: %{citations: [%{"url" => "https://docs.x.ai/overview"}]}
+        }
+      }
+
+      updated = Session.update_from_result(session, result)
+
+      assert updated.metadata == %{
+               agent: "researcher",
+               provider_state: %{response_id: "resp_789"},
+               provider_response: %{citations: [%{"url" => "https://docs.x.ai/overview"}]}
+             }
+    end
   end
 end

--- a/test/support/echo_tool.ex
+++ b/test/support/echo_tool.ex
@@ -14,7 +14,6 @@ defmodule Alloy.Test.EchoTool do
   end
 
   @impl true
-  def execute(%{"text" => text}, _context) do
-    {:ok, "Echo: #{text}"}
-  end
+  def execute(%{"text" => text}, _context), do: {:ok, "Echo: #{text}"}
+  def execute(%{text: text}, _context), do: {:ok, "Echo: #{text}"}
 end

--- a/test/support/slow_echo_tool.ex
+++ b/test/support/slow_echo_tool.ex
@@ -26,4 +26,10 @@ defmodule Alloy.Test.SlowEchoTool do
     if sleep_ms > 0, do: Process.sleep(sleep_ms)
     {:ok, "Echo: #{text}"}
   end
+
+  def execute(%{text: text} = input, _context) do
+    sleep_ms = Map.get(input, :sleep_ms, 0)
+    if sleep_ms > 0, do: Process.sleep(sleep_ms)
+    {:ok, "Echo: #{text}"}
+  end
 end


### PR DESCRIPTION
## Summary

- **EchoTool test crashes** — accept both atom and string key maps, eliminating 7 test warnings
- **Anthropic double-timeout** — removed redundant `Task.Supervisor` wrapper; `Req.receive_timeout` (from Retry) already enforces the deadline
- **6 Dialyzer warnings** — opaque `:queue` typespec → `term()`, `map_size/1` guard, removed unreachable `nil` clause
- **`stringify_keys/1` safety** — explicit string-key clause, `ArgumentError` on unexpected key types

## Test plan

- [x] `mix test` — 522 tests, 0 failures
- [x] `mix dialyzer` — 0 errors
- [x] `mix credo --strict` — no issues
- [x] `mix format --check-formatted` — clean
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)