### PR TITLE
[codex] Fix bash tool timeout override

### DIFF
--- a/lib/alloy/tool/core/bash.ex
+++ b/lib/alloy/tool/core/bash.ex
@@ -68,7 +68,7 @@ defmodule Alloy.Tool.Core.Bash do
   @impl true
   def execute(input, context) do
     command = input["command"]
-    timeout = min(input["timeout"] || @default_timeout, @default_timeout)
+    timeout = normalize_timeout(input["timeout"])
     working_dir = Map.get(context, :working_directory)
     executor = Map.get(context, :bash_executor)
 
@@ -125,6 +125,9 @@ defmodule Alloy.Tool.Core.Bash do
 
   defp maybe_add_cd(opts, nil), do: opts
   defp maybe_add_cd(opts, dir), do: Keyword.put(opts, :cd, dir)
+
+  defp normalize_timeout(timeout) when is_integer(timeout) and timeout > 0, do: timeout
+  defp normalize_timeout(_timeout), do: @default_timeout
 
   defp truncate(output) when byte_size(output) > @max_output do
     String.slice(output, 0, @max_output) <> "\n... (output truncated)"

--- a/test/alloy/tool/core/bash_test.exs
+++ b/test/alloy/tool/core/bash_test.exs
@@ -79,6 +79,16 @@ defmodule Alloy.Tool.Core.BashTest do
       assert msg =~ ~r/server|loop|input/i
     end
 
+    test "honors explicit timeouts above the default", %{tmp_dir: tmp_dir} do
+      assert {:ok, result} =
+               Bash.execute(
+                 %{"command" => "sleep 11", "timeout" => 12_000},
+                 %{working_directory: tmp_dir}
+               )
+
+      assert result =~ "exit code: 0"
+    end
+
     test "executes in bash not sh", %{tmp_dir: tmp_dir} do
       # $0 reports the name of the invoking shell: "bash" when called as bash, "sh" when called as sh
       assert {:ok, result} =


### PR DESCRIPTION
This fixes a timeout handling bug in `Alloy.Tool.Core.Bash`.

Today the Bash tool silently caps any requested timeout to the 10 second default. That means callers can pass a larger timeout in the tool input, but the tool will still kill the command after 10 seconds. In practice this makes longer-running but otherwise valid commands fail unexpectedly, even when the caller explicitly asked for more time.

The root cause is that `execute/2` normalizes the timeout with `min(input["timeout"] || @default_timeout, @default_timeout)`, which always clamps the value down to `@default_timeout`. The implementation now accepts any positive integer timeout and falls back to the default only when the input is missing or invalid.

I added a regression test that runs a command which takes longer than 10 seconds and verifies that an explicit 12 second timeout is honored. I also ran the existing Bash tool test file and the full Alloy test suite to make sure the change does not break the broader tool execution flow.

Validation used:
- `mix test test/alloy/tool/core/bash_test.exs`
- `mix test`
