### PR TITLE
[codex] Add one-shot streaming helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,18 @@ Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAICompat, api_url: "h
 
 ### Streaming
 
-Stream tokens as they arrive — works with every provider:
+For a one-shot run, use `Alloy.stream/3`:
+
+```elixir
+{:ok, result} =
+  Alloy.stream("Explain OTP", fn chunk ->
+    IO.write(chunk)
+  end,
+    provider: {Alloy.Provider.OpenAI, api_key: "...", model: "gpt-5.4"}
+  )
+```
+
+For a persistent agent process with conversation state, use `Alloy.Agent.Server.stream_chat/4`:
 
 ```elixir
 {:ok, agent} = Alloy.Agent.Server.start_link(
@@ -133,6 +144,9 @@ end)
 
 All providers support streaming. If a custom provider doesn't implement
 `stream/4`, the turn loop falls back to `complete/3` automatically.
+
+`Alloy.run/2` remains the buffered convenience API. Use `Alloy.stream/3`
+when you want the same one-shot flow with token streaming.
 
 ### Provider-owned state
 

--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -29,6 +29,14 @@ defmodule Alloy do
         messages: previous_result.messages
       )
 
+  ## One-Shot Streaming
+
+      {:ok, result} = Alloy.stream("Explain OTP", fn chunk ->
+        IO.write(chunk)
+      end,
+        provider: {Alloy.Provider.OpenAI, api_key: "sk-...", model: "gpt-5.4"}
+      )
+
   ## Options
 
   - `:provider` - `{module, config_keyword_list}` or just `module` (required)
@@ -77,12 +85,43 @@ defmodule Alloy do
   """
   @spec run(String.t() | nil, keyword()) :: {:ok, result()} | {:error, result()}
   def run(message \\ nil, opts) do
+    do_run(message, opts, [])
+  end
+
+  @doc """
+  Run the agent loop and stream text deltas as they arrive.
+
+  This is a one-shot convenience API for callers who do not need a persistent
+  `Alloy.Agent.Server` process. It returns the same result shape as `run/2`.
+
+  The first argument can be a string (converted to a user message)
+  or `nil` if the `:messages` option provides conversation history.
+
+  ## Options
+
+  Accepts the same options as `run/2`, plus:
+
+  - `:on_event` - function called with normalized event envelopes during the run
+  """
+  @spec stream(String.t() | nil, (String.t() -> any), keyword()) ::
+          {:ok, result()} | {:error, result()}
+  def stream(message, on_chunk, opts \\ []) when is_function(on_chunk, 1) do
+    on_event = validate_on_event(Keyword.get(opts, :on_event))
+
+    turn_opts =
+      [streaming: true, on_chunk: on_chunk]
+      |> maybe_put(:on_event, on_event)
+
+    do_run(message, opts, turn_opts)
+  end
+
+  defp do_run(message, opts, turn_opts) do
     config = Config.from_opts(opts)
     messages = build_messages(message, opts)
     state = %{State.init(config, messages) | status: :running}
 
     try do
-      final_state = Turn.run_loop(state)
+      final_state = Turn.run_loop(state, turn_opts)
 
       result = Result.from_state(final_state)
 
@@ -104,4 +143,14 @@ defmodule Alloy do
     existing = Keyword.get(opts, :messages, [])
     existing ++ [Message.user(text)]
   end
+
+  defp validate_on_event(nil), do: nil
+  defp validate_on_event(on_event) when is_function(on_event, 1), do: on_event
+
+  defp validate_on_event(bad) do
+    raise ArgumentError, "on_event must be a 1-arity function, got: #{inspect(bad)}"
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
 end

--- a/test/alloy_test.exs
+++ b/test/alloy_test.exs
@@ -57,6 +57,69 @@ defmodule AlloyTest do
     end
   end
 
+  describe "Alloy.stream/3" do
+    test "streams text for a one-shot conversation" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("Streaming works")
+        ])
+
+      test_pid = self()
+
+      assert {:ok, result} =
+               Alloy.stream(
+                 "Explain OTP",
+                 fn chunk -> send(test_pid, {:chunk, chunk}) end,
+                 provider: {TestProvider, agent_pid: pid}
+               )
+
+      assert result.text == "Streaming works"
+      assert result.status == :completed
+
+      assert_received {:chunk, "S"}
+      assert_received {:chunk, "t"}
+      assert_received {:chunk, "r"}
+    end
+
+    test "forwards on_event callbacks" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("OK")
+        ])
+
+      test_pid = self()
+
+      assert {:ok, result} =
+               Alloy.stream(
+                 "Hi",
+                 fn _chunk -> :ok end,
+                 provider: {TestProvider, agent_pid: pid},
+                 on_event: fn event -> send(test_pid, {:event, event}) end
+               )
+
+      assert result.status == :completed
+
+      assert_received {:event, %{event: :text_delta, payload: "O"}}
+      assert_received {:event, %{event: :text_delta, payload: "K"}}
+    end
+
+    test "raises when on_event is not a function" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("Nope")
+        ])
+
+      assert_raise ArgumentError, ~r/on_event must be a 1-arity function/, fn ->
+        Alloy.stream(
+          "Hi",
+          fn _chunk -> :ok end,
+          provider: {TestProvider, agent_pid: pid},
+          on_event: :invalid
+        )
+      end
+    end
+  end
+
   describe "Alloy.run/2 with tools" do
     test "executes tools and returns final response" do
       {:ok, pid} =


### PR DESCRIPTION
This adds a one-shot streaming convenience API to Alloy.

Today Alloy already supports streaming in two places: the lower-level turn loop accepts streaming runtime opts, and the stateful `Alloy.Agent.Server.stream_chat/4` API exposes token streaming for persistent agent processes. But callers using the top-level one-shot API only have `Alloy.run/2`, which is buffered. That leaves a gap for applications that want the same single-run ergonomics as `run/2` while still receiving text deltas as they arrive.

This PR adds `Alloy.stream/3` as that missing convenience layer. It keeps the existing architecture intact:
- `Alloy.run/2` remains the buffered one-shot API
- `Alloy.stream/3` is the streaming one-shot API
- `Alloy.Agent.Server.stream_chat/4` remains the stateful streaming API for persistent sessions

The implementation reuses the same core loop and result shape as `run/2`, but passes streaming runtime options into `Turn.run_loop/2`. It also validates the optional `:on_event` callback to match the existing server-side streaming behavior.

I added top-level integration tests covering streamed chunks, forwarded `on_event` callbacks, and invalid `on_event` input. I also updated the README so the streaming section distinguishes between one-shot streaming and server-backed streaming.

Validation used:
- `mix test test/alloy_test.exs test/alloy/streaming_test.exs`
- `mix test`
