### PR TITLE
[codex] enhance summary-based compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.6] - 2026-03-19
+
+### Added
+
+- **Grouped compaction settings** — `Alloy.run/2` now accepts `compaction: [...]` with `reserve_tokens`, `keep_recent_tokens`, and `fallback`, making context compaction behavior configurable without replacing `max_tokens`.
+
+### Changed
+
+- **Summary-first context compaction** — `Alloy.Context.Compactor` now preserves the first message, keeps a recent token-budgeted verbatim window, and replaces older context with a single structured handoff summary generated through the configured provider.
+- **Reserve-based compaction trigger** — compaction now starts when the conversation exceeds `max_tokens - reserve_tokens` instead of relying on the previous fixed 90% threshold.
+- **Repeated compactions reuse the handoff summary** — Alloy updates the existing synthetic summary message on later compactions instead of stacking multiple summaries, while still falling back to deterministic truncation if summary generation fails.
+
 ## [0.7.5] - 2026-03-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -118,7 +118,18 @@ Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAICompat, api_url: "h
 
 ### Streaming
 
-Stream tokens as they arrive — works with every provider:
+For a one-shot run, use `Alloy.stream/3`:
+
+```elixir
+{:ok, result} =
+  Alloy.stream("Explain OTP", fn chunk ->
+    IO.write(chunk)
+  end,
+    provider: {Alloy.Provider.OpenAI, api_key: "...", model: "gpt-5.4"}
+  )
+```
+
+For a persistent agent process with conversation state, use `Alloy.Agent.Server.stream_chat/4`:
 
 ```elixir
 {:ok, agent} = Alloy.Agent.Server.start_link(
@@ -133,6 +144,9 @@ end)
 
 All providers support streaming. If a custom provider doesn't implement
 `stream/4`, the turn loop falls back to `complete/3` automatically.
+
+`Alloy.run/2` remains the buffered convenience API. Use `Alloy.stream/3`
+when you want the same one-shot flow with token streaming.
 
 ### Provider-owned state
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,20 @@ Set `max_tokens` explicitly when you want a fixed compaction budget. Otherwise
 Alloy derives it from the current model, including after
 `Alloy.Agent.Server.set_model/2` switches to a different provider model.
 
+Use `compaction:` when you want to tune how much room Alloy reserves before it
+summarizes older context:
+
+```elixir
+{:ok, result} = Alloy.run("Summarise this repository",
+  provider: {Alloy.Provider.OpenAI, api_key: "...", model: "gpt-5.4"},
+  compaction: [
+    reserve_tokens: 12_000,
+    keep_recent_tokens: 8_000,
+    fallback: :truncate
+  ]
+)
+```
+
 ### Supervised GenServer agent
 
 ```elixir

--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -29,6 +29,14 @@ defmodule Alloy do
         messages: previous_result.messages
       )
 
+  ## One-Shot Streaming
+
+      {:ok, result} = Alloy.stream("Explain OTP", fn chunk ->
+        IO.write(chunk)
+      end,
+        provider: {Alloy.Provider.OpenAI, api_key: "sk-...", model: "gpt-5.4"}
+      )
+
   ## Options
 
   - `:provider` - `{module, config_keyword_list}` or just `module` (required)
@@ -77,12 +85,43 @@ defmodule Alloy do
   """
   @spec run(String.t() | nil, keyword()) :: {:ok, result()} | {:error, result()}
   def run(message \\ nil, opts) do
+    do_run(message, opts, [])
+  end
+
+  @doc """
+  Run the agent loop and stream text deltas as they arrive.
+
+  This is a one-shot convenience API for callers who do not need a persistent
+  `Alloy.Agent.Server` process. It returns the same result shape as `run/2`.
+
+  The first argument can be a string (converted to a user message)
+  or `nil` if the `:messages` option provides conversation history.
+
+  ## Options
+
+  Accepts the same options as `run/2`, plus:
+
+  - `:on_event` - function called with normalized event envelopes during the run
+  """
+  @spec stream(String.t() | nil, (String.t() -> any), keyword()) ::
+          {:ok, result()} | {:error, result()}
+  def stream(message, on_chunk, opts \\ []) when is_function(on_chunk, 1) do
+    on_event = validate_on_event(Keyword.get(opts, :on_event))
+
+    turn_opts =
+      [streaming: true, on_chunk: on_chunk]
+      |> maybe_put(:on_event, on_event)
+
+    do_run(message, opts, turn_opts)
+  end
+
+  defp do_run(message, opts, turn_opts) do
     config = Config.from_opts(opts)
     messages = build_messages(message, opts)
     state = %{State.init(config, messages) | status: :running}
 
     try do
-      final_state = Turn.run_loop(state)
+      final_state = Turn.run_loop(state, turn_opts)
 
       result = Result.from_state(final_state)
 
@@ -104,4 +143,14 @@ defmodule Alloy do
     existing = Keyword.get(opts, :messages, [])
     existing ++ [Message.user(text)]
   end
+
+  defp validate_on_event(nil), do: nil
+  defp validate_on_event(on_event) when is_function(on_event, 1), do: on_event
+
+  defp validate_on_event(bad) do
+    raise ArgumentError, "on_event must be a 1-arity function, got: #{inspect(bad)}"
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
 end

--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -45,6 +45,7 @@ defmodule Alloy do
   - `:messages` - existing conversation history (default: `[]`)
   - `:max_turns` - maximum agent loop iterations (default: `25`)
   - `:max_tokens` - context window budget for compaction (default: provider model window when known, otherwise `200_000`)
+  - `:compaction` - grouped compaction settings like `reserve_tokens`, `keep_recent_tokens`, and `fallback` (default: derived from `:max_tokens`)
   - `:middleware` - list of `Alloy.Middleware` modules (default: `[]`)
   - `:working_directory` - base path for file tools (default: `"."`)
   - `:context` - arbitrary map passed to tools and middleware (default: `%{}`)

--- a/lib/alloy/agent/config.ex
+++ b/lib/alloy/agent/config.ex
@@ -8,6 +8,12 @@ defmodule Alloy.Agent.Config do
 
   alias Alloy.ModelMetadata
 
+  @type compaction :: %{
+          reserve_tokens: pos_integer(),
+          keep_recent_tokens: pos_integer(),
+          fallback: :truncate
+        }
+
   @type t :: %__MODULE__{
           provider: module(),
           provider_config: map(),
@@ -21,6 +27,11 @@ defmodule Alloy.Agent.Config do
           timeout_ms: pos_integer(),
           tool_timeout: pos_integer(),
           middleware: [module()],
+          compaction: compaction(),
+          compaction_explicit: %{
+            reserve_tokens: boolean(),
+            keep_recent_tokens: boolean()
+          },
           working_directory: String.t(),
           context: map(),
           on_shutdown: (Alloy.Session.t() -> any()) | nil,
@@ -47,6 +58,8 @@ defmodule Alloy.Agent.Config do
     timeout_ms: 120_000,
     tool_timeout: 120_000,
     middleware: [],
+    compaction: %{reserve_tokens: 16_384, keep_recent_tokens: 20_000, fallback: :truncate},
+    compaction_explicit: %{reserve_tokens: false, keep_recent_tokens: false},
     working_directory: ".",
     context: %{},
     on_shutdown: nil,
@@ -69,25 +82,31 @@ defmodule Alloy.Agent.Config do
     model_metadata_overrides = normalize_model_metadata_overrides(opts[:model_metadata_overrides])
     max_tokens_explicit? = Keyword.has_key?(opts, :max_tokens)
 
+    max_tokens =
+      resolve_max_tokens(
+        opts,
+        provider_config,
+        model_metadata_overrides,
+        max_tokens_explicit?
+      )
+
+    {compaction, compaction_explicit} = resolve_compaction(opts[:compaction], max_tokens)
+
     %__MODULE__{
       provider: provider_mod,
       provider_config: provider_config,
       tools: Keyword.get(opts, :tools, []),
       system_prompt: Keyword.get(opts, :system_prompt),
       max_turns: Keyword.get(opts, :max_turns, 25),
-      max_tokens:
-        resolve_max_tokens(
-          opts,
-          provider_config,
-          model_metadata_overrides,
-          max_tokens_explicit?
-        ),
+      max_tokens: max_tokens,
       max_tokens_explicit?: max_tokens_explicit?,
       max_retries: Keyword.get(opts, :max_retries, 3),
       retry_backoff_ms: Keyword.get(opts, :retry_backoff_ms, 1_000),
       timeout_ms: Keyword.get(opts, :timeout_ms, 120_000),
       tool_timeout: Keyword.get(opts, :tool_timeout, 120_000),
       middleware: Keyword.get(opts, :middleware, []),
+      compaction: compaction,
+      compaction_explicit: compaction_explicit,
       working_directory: Keyword.get(opts, :working_directory, "."),
       context: Keyword.get(opts, :context, %{}),
       on_shutdown: Keyword.get(opts, :on_shutdown, nil),
@@ -122,7 +141,30 @@ defmodule Alloy.Agent.Config do
         default_max_tokens(model_name(provider_config), config.model_metadata_overrides)
       end
 
-    %{config | provider: provider_mod, provider_config: provider_config, max_tokens: max_tokens}
+    compaction =
+      %{
+        reserve_tokens:
+          resolve_compaction_field(
+            config.compaction.reserve_tokens,
+            config.compaction_explicit.reserve_tokens,
+            default_reserve_tokens(max_tokens)
+          ),
+        keep_recent_tokens:
+          resolve_compaction_field(
+            config.compaction.keep_recent_tokens,
+            config.compaction_explicit.keep_recent_tokens,
+            default_keep_recent_tokens(max_tokens)
+          ),
+        fallback: config.compaction.fallback
+      }
+
+    %{
+      config
+      | provider: provider_mod,
+        provider_config: provider_config,
+        max_tokens: max_tokens,
+        compaction: compaction
+    }
   end
 
   defp parse_provider({module, config})
@@ -175,5 +217,98 @@ defmodule Alloy.Agent.Config do
 
   defp default_max_tokens(_model_name, _model_metadata_overrides) do
     ModelMetadata.default_context_window()
+  end
+
+  defp resolve_compaction(raw_compaction, max_tokens) do
+    compaction = normalize_compaction(raw_compaction)
+
+    explicit = %{
+      reserve_tokens: Map.has_key?(compaction, :reserve_tokens),
+      keep_recent_tokens: Map.has_key?(compaction, :keep_recent_tokens)
+    }
+
+    fallback =
+      compaction
+      |> Map.get(:fallback, :truncate)
+      |> validate_compaction_fallback()
+
+    resolved = %{
+      reserve_tokens:
+        if(explicit.reserve_tokens,
+          do: validate_compaction_tokens!(compaction.reserve_tokens, :reserve_tokens),
+          else: default_reserve_tokens(max_tokens)
+        ),
+      keep_recent_tokens:
+        if(explicit.keep_recent_tokens,
+          do: validate_compaction_tokens!(compaction.keep_recent_tokens, :keep_recent_tokens),
+          else: default_keep_recent_tokens(max_tokens)
+        ),
+      fallback: fallback
+    }
+
+    {resolved, explicit}
+  end
+
+  defp normalize_compaction(nil), do: %{}
+
+  defp normalize_compaction(compaction) when is_map(compaction),
+    do: normalize_compaction_map(compaction)
+
+  defp normalize_compaction(compaction) when is_list(compaction),
+    do: normalize_compaction_map(Map.new(compaction))
+
+  defp normalize_compaction(other) do
+    raise ArgumentError,
+          "compaction must be a keyword list or map, got: #{inspect(other)}"
+  end
+
+  defp normalize_compaction_map(map) do
+    Enum.reduce(map, %{}, fn
+      {:reserve_tokens, value}, acc ->
+        Map.put(acc, :reserve_tokens, value)
+
+      {"reserve_tokens", value}, acc ->
+        Map.put(acc, :reserve_tokens, value)
+
+      {:keep_recent_tokens, value}, acc ->
+        Map.put(acc, :keep_recent_tokens, value)
+
+      {"keep_recent_tokens", value}, acc ->
+        Map.put(acc, :keep_recent_tokens, value)
+
+      {:fallback, value}, acc ->
+        Map.put(acc, :fallback, value)
+
+      {"fallback", value}, acc ->
+        Map.put(acc, :fallback, value)
+
+      {key, _value}, _acc ->
+        raise ArgumentError, "unsupported compaction option: #{inspect(key)}"
+    end)
+  end
+
+  defp resolve_compaction_field(current_value, true, _default_value), do: current_value
+  defp resolve_compaction_field(_current_value, false, default_value), do: default_value
+
+  defp validate_compaction_tokens!(value, _field) when is_integer(value) and value > 0, do: value
+
+  defp validate_compaction_tokens!(value, field) do
+    raise ArgumentError,
+          "#{field} must be a positive integer, got: #{inspect(value)}"
+  end
+
+  defp validate_compaction_fallback(:truncate), do: :truncate
+
+  defp validate_compaction_fallback(other) do
+    raise ArgumentError,
+          "compaction fallback must be :truncate, got: #{inspect(other)}"
+  end
+
+  defp default_reserve_tokens(max_tokens) do
+    min(16_384, max(1, div(max_tokens, 10)))
+  end
+
+  defp default_keep_recent_tokens(max_tokens) do
+    min(20_000, max(1, div(max_tokens, 8)))
   end
 end

--- a/lib/alloy/context/compactor.ex
+++ b/lib/alloy/context/compactor.ex
@@ -1,10 +1,11 @@
 defmodule Alloy.Context.Compactor do
   @moduledoc """
-  Manus-style context compaction.
+  Summary-based context compaction.
 
-  When approaching the token limit, compacts old tool results into
-  summaries and truncates old assistant text, preserving the first
-  message (original request) and the most recent messages.
+  When the conversation approaches the configured reserve threshold, Alloy
+  preserves the first message, keeps a recent verbatim token window, and
+  replaces older context with a structured handoff summary. If summary
+  generation fails, Alloy falls back to deterministic truncation.
   """
 
   require Logger
@@ -16,37 +17,86 @@ defmodule Alloy.Context.Compactor do
   @default_keep_recent 10
   @truncate_length 200
 
+  @summary_prefix "Previous analysis summary (from earlier in this session):"
+
+  @summary_system_prompt """
+  You are performing CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.
+
+  Include:
+  - Current progress and key decisions made
+  - Important context, constraints, or user preferences
+  - What remains to be done (clear next steps)
+  - Any critical data, examples, or references needed to continue
+
+  Be concise, structured, and focused on helping the next LLM seamlessly continue the work.
+  """
+
+  @summary_prompt """
+  Create a structured handoff summary for another language model that will resume this task.
+
+  Use this EXACT structure:
+
+  ## Goal
+  [What the user is trying to accomplish]
+
+  ## Constraints & Preferences
+  - [Important constraints, preferences, or requirements]
+  - [(none) if not applicable]
+
+  ## Progress
+  ### Done
+  - [Completed tasks, findings, or verified facts]
+
+  ### In Progress
+  - [Current work that is not finished yet]
+
+  ### Blocked
+  - [Active blockers or "(none)"]
+
+  ## Key Decisions
+  - **[Decision]**: [Brief rationale]
+
+  ## Evidence & References
+  - [Evidence chains, exact file paths, tool names, function names, or error messages]
+  - [(none) if not applicable]
+
+  ## Next Steps
+  1. [Ordered next action]
+
+  ## Critical Context
+  - [Anything the next model must preserve exactly]
+  - [(none) if not applicable]
+
+  Requirements:
+  - Preserve exact file paths, function names, tool names, error messages, and user preferences.
+  - Preserve evidence chains and clearly mark when a conclusion depends on a specific source or tool result.
+  - Only include information supported by the provided conversation and previous summary.
+  - Keep the summary concise but decision-complete enough for the next model to continue without rereading the discarded messages.
+  """
+
   @doc """
-  Compacts state messages if over the 90% token budget threshold.
-  Returns state unchanged if within budget.
+  Prefix used for synthetic handoff summary messages inserted by the compactor.
+  """
+  @spec summary_prefix() :: String.t()
+  def summary_prefix, do: @summary_prefix
+
+  @doc """
+  Compacts state messages when they exceed `max_tokens - reserve_tokens`.
+  Returns state unchanged when within budget.
   """
   @spec maybe_compact(State.t()) :: State.t()
   def maybe_compact(%State{} = state) do
     messages = State.messages(state)
+    reserve_tokens = state.config.compaction.reserve_tokens
 
-    if TokenCounter.within_budget?(messages, state.config.max_tokens) do
+    if TokenCounter.within_reserve?(messages, state.config.max_tokens, reserve_tokens) do
       state
     else
-      # Use dynamic keep_recent: at most default, but ensure at least 1 message gets compacted
-      msg_count = length(messages)
-      keep_recent = min(@default_keep_recent, max(1, msg_count - 2))
-
-      {first, middle, recent} = split_messages(messages, keep_recent)
-
-      # Fire on_compaction callback BEFORE compacting, so the caller can
-      # extract facts from messages that are about to be compressed.
-      # Crash protection: callback failure must never prevent compaction.
-      fire_on_compaction(middle, state)
-
-      compacted_middle = Enum.map(middle, &compact_message/1)
-      compacted = [first | compacted_middle] ++ recent
-
-      # Store compacted messages and clear the accumulator
-      %{state | messages: compacted, messages_new: []}
+      compact_messages_in_state(state, messages)
     end
   end
 
-  # Splits messages into {first, middle, recent} for compaction.
+  # Splits messages into {first, middle, recent} for truncation compaction.
   # The middle slice is what gets compacted; first and recent are preserved.
   defp split_messages(messages, keep_recent) do
     [first | rest] = messages
@@ -56,8 +106,266 @@ defmodule Alloy.Context.Compactor do
     {first, middle, recent}
   end
 
-  # Fires the on_compaction callback with the middle messages (those about to be
-  # compacted). Any crash in the callback is swallowed — compaction must always proceed.
+  defp compact_messages_in_state(%State{} = state, messages) do
+    keep_recent_tokens = state.config.compaction.keep_recent_tokens
+
+    case prepare_summary_compaction(messages, keep_recent_tokens) do
+      {:ok, prepared} ->
+        fire_on_compaction(prepared.messages_to_summarize, state)
+
+        case summarize_compaction(prepared, state) do
+          {:ok, summary_text} ->
+            compacted = [prepared.first, build_summary_message(summary_text) | prepared.recent]
+            %{state | messages: compacted, messages_new: []}
+
+          {:error, reason} ->
+            Logger.warning(
+              "summary compaction failed, falling back to truncation: #{inspect(reason)}"
+            )
+
+            fallback_compact_state(state, messages)
+        end
+
+      :noop ->
+        fallback_compact_state(state, messages)
+    end
+  end
+
+  defp fallback_compact_state(%State{} = state, messages) do
+    case state.config.compaction.fallback do
+      :truncate ->
+        msg_count = length(messages)
+        keep_recent = min(@default_keep_recent, max(1, msg_count - 2))
+        compacted = compact_messages(messages, keep_recent: keep_recent)
+        %{state | messages: compacted, messages_new: []}
+    end
+  end
+
+  defp prepare_summary_compaction([first | rest], keep_recent_tokens) do
+    {previous_summary, tail} = pop_existing_summary(rest)
+
+    if tail == [] do
+      :noop
+    else
+      cut_index = find_cut_point(tail, keep_recent_tokens)
+      messages_to_summarize = Enum.take(tail, cut_index)
+      recent = Enum.drop(tail, cut_index)
+
+      if messages_to_summarize == [] do
+        :noop
+      else
+        {:ok,
+         %{
+           first: first,
+           previous_summary: previous_summary,
+           messages_to_summarize: messages_to_summarize,
+           recent: recent
+         }}
+      end
+    end
+  end
+
+  defp prepare_summary_compaction(_, _keep_recent_tokens), do: :noop
+
+  defp pop_existing_summary([message | rest]) do
+    if summary_message?(message), do: {message, rest}, else: {nil, [message | rest]}
+  end
+
+  defp pop_existing_summary([]), do: {nil, []}
+
+  defp summarize_compaction(prepared, %State{} = state) do
+    provider = state.config.provider
+
+    config =
+      state.config.provider_config
+      |> Map.delete(:provider_state)
+      |> Map.delete("provider_state")
+      |> Map.put(:system_prompt, @summary_system_prompt)
+
+    prompt = build_summary_prompt(prepared.messages_to_summarize, prepared.previous_summary)
+
+    with {:ok, response} <- provider.complete([Message.user(prompt)], [], config),
+         {:ok, summary_text} <- extract_summary_text(response) do
+      {:ok, summary_text}
+    else
+      {:error, reason} -> {:error, reason}
+      other -> {:error, other}
+    end
+  end
+
+  defp build_summary_prompt(messages_to_summarize, previous_summary) do
+    previous_summary_section =
+      case previous_summary do
+        nil ->
+          ""
+
+        %Message{} = message ->
+          "<previous-summary>\n#{summary_body(message)}\n</previous-summary>\n\n"
+      end
+
+    """
+    #{previous_summary_section}<conversation>
+    #{serialize_messages(messages_to_summarize)}
+    </conversation>
+
+    #{@summary_prompt}
+    """
+  end
+
+  defp extract_summary_text(%{messages: messages}) when is_list(messages) do
+    summary_text =
+      messages
+      |> Enum.reverse()
+      |> Enum.find_value(fn
+        %Message{role: :assistant} = message ->
+          case Message.text(message) |> String.trim() do
+            "" -> nil
+            text -> text
+          end
+
+        _ ->
+          nil
+      end)
+
+    if summary_text do
+      {:ok, summary_text}
+    else
+      {:error, :empty_summary}
+    end
+  end
+
+  defp extract_summary_text(_response), do: {:error, :invalid_summary_response}
+
+  defp build_summary_message(summary_text) do
+    %Message{role: :user, content: "#{@summary_prefix}\n#{String.trim(summary_text)}"}
+  end
+
+  defp summary_message?(%Message{role: :user, content: content}) when is_binary(content) do
+    String.starts_with?(content, @summary_prefix)
+  end
+
+  defp summary_message?(_message), do: false
+
+  defp summary_body(%Message{content: content}) when is_binary(content) do
+    content
+    |> String.replace_prefix(@summary_prefix, "")
+    |> String.trim()
+  end
+
+  defp find_cut_point(messages, keep_recent_tokens) when is_list(messages) and messages != [] do
+    threshold_index = find_threshold_index(messages, keep_recent_tokens)
+    last_index = length(messages) - 1
+
+    user_cut =
+      threshold_index..last_index
+      |> Enum.find(fn index -> real_user_message?(Enum.at(messages, index)) end)
+
+    assistant_cut =
+      threshold_index..last_index
+      |> Enum.find(fn index -> assistant_message?(Enum.at(messages, index)) end)
+
+    fallback_cut =
+      0..threshold_index
+      |> Enum.reverse()
+      |> Enum.find(fn index -> valid_cut_message?(Enum.at(messages, index)) end)
+
+    user_cut || assistant_cut || fallback_cut || 0
+  end
+
+  defp find_cut_point(_messages, _keep_recent_tokens), do: 0
+
+  defp find_threshold_index(messages, keep_recent_tokens) do
+    max_index = length(messages) - 1
+
+    Enum.reduce_while(max_index..0//-1, {0, 0}, fn index,
+                                                   {_threshold_index, accumulated_tokens} ->
+      accumulated_tokens =
+        accumulated_tokens + TokenCounter.estimate_message_tokens(Enum.at(messages, index))
+
+      if accumulated_tokens >= keep_recent_tokens do
+        {:halt, {index, accumulated_tokens}}
+      else
+        {:cont, {0, accumulated_tokens}}
+      end
+    end)
+    |> elem(0)
+  end
+
+  defp real_user_message?(%Message{role: :user} = message) do
+    not tool_result_message?(message) and not summary_message?(message)
+  end
+
+  defp real_user_message?(_message), do: false
+
+  defp assistant_message?(%Message{role: :assistant}), do: true
+  defp assistant_message?(_message), do: false
+
+  defp valid_cut_message?(message), do: real_user_message?(message) or assistant_message?(message)
+
+  defp tool_result_message?(%Message{role: :user, content: blocks}) when is_list(blocks) do
+    Enum.any?(blocks, fn
+      %{type: type} when type in ["tool_result", "server_tool_result"] -> true
+      _ -> false
+    end)
+  end
+
+  defp tool_result_message?(_message), do: false
+
+  defp serialize_messages(messages) do
+    messages
+    |> Enum.map(&serialize_message/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n\n")
+  end
+
+  defp serialize_message(%Message{role: role, content: content}) when is_binary(content) do
+    "[#{role_label(role)}]\n#{content}"
+  end
+
+  defp serialize_message(%Message{role: role, content: blocks}) when is_list(blocks) do
+    blocks
+    |> Enum.map(&serialize_block(role, &1))
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp serialize_block(role, %{type: "text", text: text}) when is_binary(text) do
+    "[#{role_label(role)}]\n#{text}"
+  end
+
+  defp serialize_block(:assistant, %{type: "thinking", thinking: text}) when is_binary(text) do
+    "[Assistant thinking]\n#{text}"
+  end
+
+  defp serialize_block(:assistant, %{type: type, name: name, input: input})
+       when type in ["tool_use", "server_tool_use"] do
+    "[Assistant tool call] #{name}(#{encode_block_data(input)})"
+  end
+
+  defp serialize_block(_role, %{type: type, content: content})
+       when type in ["tool_result", "server_tool_result"] do
+    "[Tool result]\n#{block_content_to_string(content)}"
+  end
+
+  defp serialize_block(role, block) do
+    "[#{role_label(role)} block #{Map.get(block, :type, "unknown")}]\n#{inspect(block)}"
+  end
+
+  defp encode_block_data(data) do
+    case Jason.encode(data) do
+      {:ok, json} -> json
+      {:error, _} -> inspect(data)
+    end
+  end
+
+  defp block_content_to_string(content) when is_binary(content), do: content
+  defp block_content_to_string(content), do: inspect(content)
+
+  defp role_label(:user), do: "User"
+  defp role_label(:assistant), do: "Assistant"
+
+  # Fires the on_compaction callback with the messages that are about to be
+  # summarized. Any crash in the callback is swallowed — compaction must always proceed.
   defp fire_on_compaction(_middle, %State{config: %{on_compaction: nil}}), do: :ok
 
   defp fire_on_compaction(
@@ -89,6 +397,9 @@ defmodule Alloy.Context.Compactor do
   @doc """
   Compacts messages, preserving the first message and the most recent N messages.
 
+  This helper intentionally stays deterministic and provider-free so it can serve
+  as the fallback truncation strategy.
+
   ## Options
     * `:keep_recent` - number of recent messages to preserve (default #{@default_keep_recent})
   """
@@ -109,7 +420,7 @@ defmodule Alloy.Context.Compactor do
   defp compact_message(%Message{content: blocks} = msg) when is_list(blocks) do
     compacted_blocks =
       Enum.map(blocks, fn
-        %{type: "tool_result"} = block ->
+        %{type: type} = block when type in ["tool_result", "server_tool_result"] ->
           %{block | content: "[compacted]"}
 
         %{type: "thinking", thinking: text} = block when byte_size(text) > @truncate_length ->

--- a/lib/alloy/context/token_counter.ex
+++ b/lib/alloy/context/token_counter.ex
@@ -113,4 +113,14 @@ defmodule Alloy.Context.TokenCounter do
   def within_budget?(messages, max_tokens, ratio \\ @default_budget_ratio) do
     estimate_tokens(messages) < max_tokens * ratio
   end
+
+  @doc """
+  Returns true if the estimated token count stays within `max_tokens`
+  after reserving `reserve_tokens` for future work like compaction summaries
+  or model responses.
+  """
+  @spec within_reserve?([Message.t()], pos_integer(), non_neg_integer()) :: boolean()
+  def within_reserve?(messages, max_tokens, reserve_tokens) do
+    estimate_tokens(messages) <= max(max_tokens - reserve_tokens, 0)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.7.5"
+  @version "0.7.6"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do

--- a/test/alloy/agent/config_test.exs
+++ b/test/alloy/agent/config_test.exs
@@ -67,4 +67,49 @@ defmodule Alloy.Agent.ConfigTest do
       assert config.code_execution == false
     end
   end
+
+  describe "compaction option" do
+    test "derives reserve and keep_recent token defaults from max_tokens" do
+      config =
+        Config.from_opts(
+          provider: {Alloy.Provider.Test, []},
+          max_tokens: 80
+        )
+
+      assert config.compaction == %{
+               reserve_tokens: 8,
+               keep_recent_tokens: 10,
+               fallback: :truncate
+             }
+    end
+
+    test "accepts explicit compaction overrides" do
+      config =
+        Config.from_opts(
+          provider: {Alloy.Provider.Test, []},
+          max_tokens: 100,
+          compaction: [reserve_tokens: 12, keep_recent_tokens: 34, fallback: :truncate]
+        )
+
+      assert config.compaction == %{
+               reserve_tokens: 12,
+               keep_recent_tokens: 34,
+               fallback: :truncate
+             }
+    end
+
+    test "scales defaults safely for very small max_tokens" do
+      config =
+        Config.from_opts(
+          provider: {Alloy.Provider.Test, []},
+          max_tokens: 5
+        )
+
+      assert config.compaction == %{
+               reserve_tokens: 1,
+               keep_recent_tokens: 1,
+               fallback: :truncate
+             }
+    end
+  end
 end

--- a/test/alloy/context/compactor_test.exs
+++ b/test/alloy/context/compactor_test.exs
@@ -4,50 +4,327 @@ defmodule Alloy.Context.CompactorTest do
   alias Alloy.Agent.{Config, State}
   alias Alloy.Context.Compactor
   alias Alloy.Message
+  alias Alloy.Provider.Test, as: TestProvider
 
-  defp build_state(messages, max_tokens \\ 200_000) do
-    config = %Config{
-      provider: Alloy.Provider.Test,
-      provider_config: %{},
-      max_tokens: max_tokens
+  defmodule ProbeProvider do
+    @behaviour Alloy.Provider
+
+    @impl Alloy.Provider
+    def complete(
+          messages,
+          tool_defs,
+          %{summary_response: summary_response, test_pid: test_pid} = config
+        ) do
+      send(test_pid, {:summary_request, messages, tool_defs, config})
+
+      case summary_response do
+        {:ok, text} when is_binary(text) ->
+          TestProvider.text_response(text)
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp build_state(messages, opts) do
+    provider = Keyword.get(opts, :provider, TestProvider)
+    provider_config = Keyword.get(opts, :provider_config, %{})
+    max_tokens = Keyword.get(opts, :max_tokens, 200_000)
+    compaction = Keyword.get(opts, :compaction, [])
+    on_compaction = Keyword.get(opts, :on_compaction)
+
+    config =
+      Config.from_opts(
+        provider: {provider, provider_config},
+        max_tokens: max_tokens,
+        compaction: compaction,
+        on_compaction: on_compaction
+      )
+
+    %State{
+      config: config,
+      messages: messages,
+      messages_new: [],
+      provider_state: Keyword.get(opts, :provider_state, %{})
     }
+  end
 
-    %State{config: config, messages: messages}
+  defp start_scripted_provider(responses) do
+    {:ok, pid} = TestProvider.start_link(responses)
+    pid
+  end
+
+  defp summary_text(label) do
+    """
+    ## Goal
+    #{label} goal
+
+    ## Constraints & Preferences
+    - keep exact paths
+
+    ## Progress
+    ### Done
+    - [x] #{label} done
+
+    ### In Progress
+    - [ ] #{label} in progress
+
+    ### Blocked
+    - (none)
+
+    ## Key Decisions
+    - **#{label} decision**: preserve evidence
+
+    ## Evidence & References
+    - /tmp/#{String.downcase(label)}.ex
+
+    ## Next Steps
+    1. Continue #{String.downcase(label)}
+
+    ## Critical Context
+    - #{label} context
+    """
+  end
+
+  defp summary_message?(%Message{content: content}) when is_binary(content) do
+    String.starts_with?(content, Compactor.summary_prefix())
+  end
+
+  defp summary_message?(_message), do: false
+
+  defp tool_result_message?(%Message{role: :user, content: blocks}) when is_list(blocks) do
+    Enum.any?(blocks, fn
+      %{type: type} when type in ["tool_result", "server_tool_result"] -> true
+      _ -> false
+    end)
+  end
+
+  defp tool_result_message?(_message), do: false
+
+  defp assistant_tool_call_message?(%Message{role: :assistant, content: blocks})
+       when is_list(blocks) do
+    Enum.any?(blocks, fn
+      %{type: type} when type in ["tool_use", "server_tool_use"] -> true
+      _ -> false
+    end)
+  end
+
+  defp assistant_tool_call_message?(_message), do: false
+
+  defp tool_pairs_intact?(messages) do
+    Enum.with_index(messages)
+    |> Enum.all?(fn
+      {%Message{} = message, index} when index > 0 ->
+        if tool_result_message?(message) do
+          assistant_tool_call_message?(Enum.at(messages, index - 1))
+        else
+          true
+        end
+
+      {%Message{} = message, 0} ->
+        not tool_result_message?(message)
+    end)
   end
 
   describe "maybe_compact/1" do
-    test "returns state unchanged when within budget" do
+    test "returns state unchanged when within reserve budget" do
       messages = [Message.user("hello"), Message.assistant("hi")]
-      state = build_state(messages)
+
+      state =
+        build_state(messages,
+          max_tokens: 200,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("unused")}, test_pid: self()}
+        )
 
       assert Compactor.maybe_compact(state) == state
+      refute_received {:summary_request, _, _, _}
     end
 
-    test "compacts messages when over budget" do
-      # Build messages that exceed 90% of a small token budget
-      # 1200 chars / 4 = 300 tokens, budget 90% of 250 = 225
-      big_result = String.duplicate("x", 1200)
-
+    test "invokes the provider summarizer and stores a synthetic summary message" do
       messages = [
         Message.user("original request"),
+        Message.assistant(String.duplicate("a", 900)),
+        Message.user("middle question"),
+        Message.assistant("recent reply"),
+        Message.user("latest")
+      ]
+
+      state =
+        build_state(messages,
+          max_tokens: 250,
+          compaction: [reserve_tokens: 25, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Alpha")}, test_pid: self()},
+          provider_state: %{response_id: "should-not-leak"}
+        )
+
+      compacted = Compactor.maybe_compact(state)
+
+      assert_received {:summary_request, [%Message{role: :user, content: prompt}], [], config}
+      assert prompt =~ "<conversation>"
+      assert prompt =~ "## Goal"
+      refute Map.has_key?(config, :provider_state)
+
+      assert hd(compacted.messages).content == "original request"
+      assert Enum.at(compacted.messages, 1).role == :user
+      assert summary_message?(Enum.at(compacted.messages, 1))
+      assert Enum.at(compacted.messages, 1).content =~ "Alpha goal"
+    end
+
+    test "preserves recent messages intact based on the keep_recent_tokens budget" do
+      messages = [
+        Message.user("original"),
+        Message.assistant(String.duplicate("a", 800)),
+        Message.user(String.duplicate("b", 400)),
+        Message.assistant("recent 1"),
+        Message.user("recent 2"),
+        Message.assistant("recent 3"),
+        Message.user("recent 4"),
+        Message.assistant("recent 5")
+      ]
+
+      state =
+        build_state(messages,
+          max_tokens: 260,
+          compaction: [reserve_tokens: 25, keep_recent_tokens: 50],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Recent")}, test_pid: self()}
+        )
+
+      compacted = Compactor.maybe_compact(state)
+
+      assert Enum.take(compacted.messages, -5) == Enum.take(messages, -5)
+    end
+
+    test "updates the existing summary instead of duplicating it" do
+      provider_pid =
+        start_scripted_provider([
+          TestProvider.text_response(summary_text("First")),
+          TestProvider.text_response(summary_text("Updated"))
+        ])
+
+      initial_messages = [
+        Message.user("original"),
+        Message.assistant(String.duplicate("a", 900)),
+        Message.user("recent")
+      ]
+
+      state =
+        build_state(initial_messages,
+          max_tokens: 180,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: TestProvider,
+          provider_config: %{agent_pid: provider_pid}
+        )
+
+      first_compaction = Compactor.maybe_compact(state)
+
+      second_state = %{
+        first_compaction
+        | messages:
+            first_compaction.messages ++
+              [Message.assistant(String.duplicate("b", 900)), Message.user("new latest")],
+          messages_new: []
+      }
+
+      second_compaction = Compactor.maybe_compact(second_state)
+
+      summary_messages = Enum.filter(second_compaction.messages, &summary_message?/1)
+
+      assert length(summary_messages) == 1
+      assert hd(summary_messages).content =~ "Updated goal"
+      refute hd(summary_messages).content =~ "First goal"
+    end
+
+    test "never leaves a kept tool result without its assistant tool call" do
+      big_result = String.duplicate("r", 900)
+
+      messages = [
+        Message.user("original"),
+        Message.user("inspect the file"),
+        Message.assistant_blocks([
+          %{type: "tool_use", id: "t1", name: "read_file", input: %{path: "lib/foo.ex"}}
+        ]),
         Message.tool_results([
           %{type: "tool_result", tool_use_id: "t1", content: big_result}
         ]),
-        Message.assistant("analysis of results"),
-        Message.user("follow up")
+        Message.assistant("analysis after tool"),
+        Message.assistant("latest note")
       ]
 
-      state = build_state(messages, 250)
+      state =
+        build_state(messages,
+          max_tokens: 260,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 5],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Tool")}, test_pid: self()}
+        )
+
       compacted = Compactor.maybe_compact(state)
 
-      # Should have compacted the tool results
-      refute compacted == state
-      assert length(compacted.messages) == length(messages)
+      assert tool_pairs_intact?(Enum.drop(compacted.messages, 2))
+      refute tool_result_message?(Enum.at(compacted.messages, 2))
+    end
+
+    test "can compact a large single turn by keeping an assistant suffix verbatim" do
+      messages = [
+        Message.user("original"),
+        Message.user("one big turn"),
+        Message.assistant(String.duplicate("a", 900)),
+        Message.assistant(String.duplicate("b", 900)),
+        Message.assistant("tail that should stay verbatim")
+      ]
+
+      state =
+        build_state(messages,
+          max_tokens: 300,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Split")}, test_pid: self()}
+        )
+
+      compacted = Compactor.maybe_compact(state)
+
+      assert summary_message?(Enum.at(compacted.messages, 1))
+      assert Enum.at(compacted.messages, 2) == Enum.at(messages, 3)
+      assert Enum.at(compacted.messages, 3) == Enum.at(messages, 4)
+    end
+
+    test "falls back to truncation when summary generation fails" do
+      long_text = String.duplicate("a", 500)
+
+      messages = [
+        Message.user("original"),
+        Message.assistant(long_text),
+        Message.assistant("recent"),
+        Message.user("latest")
+      ]
+
+      state =
+        build_state(messages,
+          max_tokens: 120,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:error, :boom}, test_pid: self()}
+        )
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          compacted = Compactor.maybe_compact(state)
+          compacted_msg = Enum.at(compacted.messages, 1)
+          assert String.length(compacted_msg.content) <= 203
+          refute Enum.any?(compacted.messages, &summary_message?/1)
+        end)
+
+      assert log =~ "summary compaction failed, falling back to truncation"
     end
   end
 
   describe "on_compaction callback" do
-    test "fires callback with middle messages before compaction" do
+    test "fires callback with messages about to be summarized" do
       test_pid = self()
 
       callback = fn middle_messages, state ->
@@ -55,26 +332,23 @@ defmodule Alloy.Context.CompactorTest do
         :ok
       end
 
-      # Build messages that exceed 90% of a small token budget
-      big_text = String.duplicate("x", 1200)
-
       messages = [
         Message.user("original request"),
-        Message.assistant(big_text),
+        Message.assistant(String.duplicate("x", 1200)),
         Message.user("middle question"),
         Message.assistant("middle answer"),
         Message.assistant("recent reply"),
         Message.user("latest")
       ]
 
-      config = %Config{
-        provider: Alloy.Provider.Test,
-        provider_config: %{},
-        max_tokens: 250,
-        on_compaction: callback
-      }
-
-      state = %State{config: config, messages: messages, messages_new: []}
+      state =
+        build_state(messages,
+          max_tokens: 250,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Callback")}, test_pid: self()},
+          on_compaction: callback
+        )
 
       _compacted = Compactor.maybe_compact(state)
 
@@ -93,14 +367,14 @@ defmodule Alloy.Context.CompactorTest do
 
       messages = [Message.user("hi"), Message.assistant("hello")]
 
-      config = %Config{
-        provider: Alloy.Provider.Test,
-        provider_config: %{},
-        max_tokens: 200_000,
-        on_compaction: callback
-      }
-
-      state = %State{config: config, messages: messages, messages_new: []}
+      state =
+        build_state(messages,
+          max_tokens: 200,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("unused")}, test_pid: self()},
+          on_compaction: callback
+        )
 
       _result = Compactor.maybe_compact(state)
 
@@ -108,21 +382,25 @@ defmodule Alloy.Context.CompactorTest do
     end
 
     test "compaction still works when on_compaction is nil" do
-      big_text = String.duplicate("x", 1200)
-
       messages = [
         Message.user("original"),
-        Message.assistant(big_text),
+        Message.assistant(String.duplicate("x", 1200)),
         Message.user("middle"),
         Message.assistant("recent"),
         Message.user("latest")
       ]
 
-      state = build_state(messages, 250)
+      state =
+        build_state(messages,
+          max_tokens: 250,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Nil")}, test_pid: self()}
+        )
 
       compacted = Compactor.maybe_compact(state)
       assert %State{} = compacted
-      refute compacted == state
+      assert Enum.any?(compacted.messages, &summary_message?/1)
     end
 
     test "compaction proceeds even when on_compaction crashes" do
@@ -130,28 +408,26 @@ defmodule Alloy.Context.CompactorTest do
         raise "Boom! Callback crashed!"
       end
 
-      big_text = String.duplicate("x", 1200)
-
       messages = [
         Message.user("original"),
-        Message.assistant(big_text),
+        Message.assistant(String.duplicate("x", 1200)),
         Message.user("middle"),
         Message.assistant("recent"),
         Message.user("latest")
       ]
 
-      config = %Config{
-        provider: Alloy.Provider.Test,
-        provider_config: %{},
-        max_tokens: 250,
-        on_compaction: callback
-      }
+      state =
+        build_state(messages,
+          max_tokens: 250,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Crash")}, test_pid: self()},
+          on_compaction: callback
+        )
 
-      state = %State{config: config, messages: messages, messages_new: []}
-
-      # Should NOT raise — crash is swallowed
       compacted = Compactor.maybe_compact(state)
       assert %State{} = compacted
+      assert Enum.any?(compacted.messages, &summary_message?/1)
     end
 
     test "logs stacktrace when on_compaction raises" do
@@ -159,24 +435,22 @@ defmodule Alloy.Context.CompactorTest do
         raise "Boom! Callback crashed!"
       end
 
-      big_text = String.duplicate("x", 1200)
-
       messages = [
         Message.user("original"),
-        Message.assistant(big_text),
+        Message.assistant(String.duplicate("x", 1200)),
         Message.user("middle"),
         Message.assistant("recent"),
         Message.user("latest")
       ]
 
-      config = %Config{
-        provider: Alloy.Provider.Test,
-        provider_config: %{},
-        max_tokens: 250,
-        on_compaction: callback
-      }
-
-      state = %State{config: config, messages: messages, messages_new: []}
+      state =
+        build_state(messages,
+          max_tokens: 250,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Raise")}, test_pid: self()},
+          on_compaction: callback
+        )
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
@@ -192,24 +466,22 @@ defmodule Alloy.Context.CompactorTest do
         throw(:kaboom)
       end
 
-      big_text = String.duplicate("x", 1200)
-
       messages = [
         Message.user("original"),
-        Message.assistant(big_text),
+        Message.assistant(String.duplicate("x", 1200)),
         Message.user("middle"),
         Message.assistant("recent"),
         Message.user("latest")
       ]
 
-      config = %Config{
-        provider: Alloy.Provider.Test,
-        provider_config: %{},
-        max_tokens: 250,
-        on_compaction: callback
-      }
-
-      state = %State{config: config, messages: messages, messages_new: []}
+      state =
+        build_state(messages,
+          max_tokens: 250,
+          compaction: [reserve_tokens: 20, keep_recent_tokens: 20],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Throw")}, test_pid: self()},
+          on_compaction: callback
+        )
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
@@ -286,7 +558,6 @@ defmodule Alloy.Context.CompactorTest do
 
       compacted = Compactor.compact_messages(messages, keep_recent: 2)
 
-      # The tool_result message (index 1) should be compacted
       compacted_msg = Enum.at(compacted, 1)
       [block] = compacted_msg.content
       assert block.content == "[compacted]"
@@ -304,7 +575,6 @@ defmodule Alloy.Context.CompactorTest do
 
       compacted = Compactor.compact_messages(messages, keep_recent: 2)
 
-      # The old assistant message should be truncated to 200 chars + "..."
       compacted_msg = Enum.at(compacted, 1)
       assert String.length(compacted_msg.content) <= 203
     end

--- a/test/alloy/context/token_counter_test.exs
+++ b/test/alloy/context/token_counter_test.exs
@@ -219,4 +219,16 @@ defmodule Alloy.Context.TokenCounterTest do
       refute TokenCounter.within_budget?(messages, 1000)
     end
   end
+
+  describe "within_reserve?/3" do
+    test "returns true when the reserve still leaves enough room" do
+      messages = [Message.user(String.duplicate("a", 200))]
+      assert TokenCounter.within_reserve?(messages, 100, 40)
+    end
+
+    test "returns false when the reserve threshold is exceeded" do
+      messages = [Message.user(String.duplicate("a", 260))]
+      refute TokenCounter.within_reserve?(messages, 100, 40)
+    end
+  end
 end

--- a/test/alloy_test.exs
+++ b/test/alloy_test.exs
@@ -57,6 +57,69 @@ defmodule AlloyTest do
     end
   end
 
+  describe "Alloy.stream/3" do
+    test "streams text for a one-shot conversation" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("Streaming works")
+        ])
+
+      test_pid = self()
+
+      assert {:ok, result} =
+               Alloy.stream(
+                 "Explain OTP",
+                 fn chunk -> send(test_pid, {:chunk, chunk}) end,
+                 provider: {TestProvider, agent_pid: pid}
+               )
+
+      assert result.text == "Streaming works"
+      assert result.status == :completed
+
+      assert_received {:chunk, "S"}
+      assert_received {:chunk, "t"}
+      assert_received {:chunk, "r"}
+    end
+
+    test "forwards on_event callbacks" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("OK")
+        ])
+
+      test_pid = self()
+
+      assert {:ok, result} =
+               Alloy.stream(
+                 "Hi",
+                 fn _chunk -> :ok end,
+                 provider: {TestProvider, agent_pid: pid},
+                 on_event: fn event -> send(test_pid, {:event, event}) end
+               )
+
+      assert result.status == :completed
+
+      assert_received {:event, %{event: :text_delta, payload: "O"}}
+      assert_received {:event, %{event: :text_delta, payload: "K"}}
+    end
+
+    test "raises when on_event is not a function" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("Nope")
+        ])
+
+      assert_raise ArgumentError, ~r/on_event must be a 1-arity function/, fn ->
+        Alloy.stream(
+          "Hi",
+          fn _chunk -> :ok end,
+          provider: {TestProvider, agent_pid: pid},
+          on_event: :invalid
+        )
+      end
+    end
+  end
+
   describe "Alloy.run/2 with tools" do
     test "executes tools and returns final response" do
       {:ok, pid} =


### PR DESCRIPTION
## Summary

This PR upgrades Alloy's core compactor from truncation-first behavior to summary-based compaction.

It adds grouped `compaction:` settings, switches compaction triggering to an explicit reserve threshold, preserves a recent verbatim token window, and inserts a single canonical handoff summary message after the original user request. If summary generation fails, Alloy falls back to the existing deterministic truncation path.

## Problem

The previous compactor primarily compacted by truncating older messages and tool results. That keeps the session within budget, but it loses important continuity for longer-running agents: progress, decisions, constraints, evidence chains, and next steps can all be partially discarded.

## Root Cause

Compaction was based on a fixed ratio and message-count slicing rather than:

- an explicit reserve budget for future work
- token-aware recent-context preservation
- a durable handoff summary lifecycle
- a safe path to reuse earlier summary state across repeated compactions

## What Changed

- Added grouped `compaction:` config with:
  - `reserve_tokens`
  - `keep_recent_tokens`
  - `fallback`
- Replaced the old 90% trigger with `max_tokens - reserve_tokens`
- Added provider-driven summary compaction through `provider.complete/3`
- Preserved the first message and recent verbatim context
- Inserted one canonical synthetic summary message instead of stacking summaries
- Updated repeated compactions to replace the existing summary
- Kept `compact_messages/2` deterministic and provider-free as the fallback truncation helper
- Expanded tests for config parsing, reserve-aware budgeting, repeated compactions, tool-call/result boundaries, fallback behavior, and callback handling
- Documented the new option in the README and `Alloy.run/2` docs

## Why This Shape

This keeps the framework change focused on Alloy's core compactor, which is the right seam for summary-based context preservation. Guardrails and application-specific handoff validation remain better fits for middleware or app-layer orchestration rather than new core primitives in this pass.

## Validation

- `mix test`
- pre-commit checks:
  - `mix format --check-formatted`
  - `mix compile --warnings-as-errors`
  - `mix credo --strict`
