### PR TITLE
feat: add max_budget_cents cost guard

### DIFF
--- a/lib/alloy/agent/config.ex
+++ b/lib/alloy/agent/config.ex
@@ -41,7 +41,8 @@ defmodule Alloy.Agent.Config do
           max_pending: non_neg_integer(),
           fallback_providers: [{module(), map()}],
           code_execution: boolean(),
-          model_metadata_overrides: map()
+          model_metadata_overrides: map(),
+          max_budget_cents: number() | nil
         }
 
   @enforce_keys [:provider, :provider_config]
@@ -69,7 +70,8 @@ defmodule Alloy.Agent.Config do
     max_pending: 0,
     fallback_providers: [],
     code_execution: false,
-    model_metadata_overrides: %{}
+    model_metadata_overrides: %{},
+    max_budget_cents: nil
   ]
 
   @doc """
@@ -119,7 +121,8 @@ defmodule Alloy.Agent.Config do
         |> Keyword.get(:fallback_providers, [])
         |> Enum.map(&parse_fallback_provider/1),
       code_execution: Keyword.get(opts, :code_execution, false),
-      model_metadata_overrides: model_metadata_overrides
+      model_metadata_overrides: model_metadata_overrides,
+      max_budget_cents: Keyword.get(opts, :max_budget_cents)
     }
   end
 

--- a/lib/alloy/agent/state.ex
+++ b/lib/alloy/agent/state.ex
@@ -9,7 +9,7 @@ defmodule Alloy.Agent.State do
   alias Alloy.Agent.Config
   alias Alloy.{Message, Usage}
 
-  @type status :: :idle | :running | :completed | :error | :max_turns | :halted
+  @type status :: :idle | :running | :completed | :error | :max_turns | :budget_exceeded | :halted
 
   @type t :: %__MODULE__{
           config: Config.t(),

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -53,6 +53,14 @@ defmodule Alloy.Agent.Turn do
   end
 
   defp do_turn(%State{} = state, opts, deadline) do
+    if budget_exceeded?(state) do
+      %{state | status: :budget_exceeded}
+    else
+      do_turn_inner(state, opts, deadline)
+    end
+  end
+
+  defp do_turn_inner(%State{} = state, opts, deadline) do
     state = Compactor.maybe_compact(state)
 
     case Middleware.run(:before_completion, state) do
@@ -186,5 +194,11 @@ defmodule Alloy.Agent.Turn do
 
   defp extract_tool_calls(messages) do
     Enum.flat_map(messages, &Message.tool_calls/1)
+  end
+
+  defp budget_exceeded?(%State{config: %{max_budget_cents: nil}}), do: false
+
+  defp budget_exceeded?(%State{config: %{max_budget_cents: max}, usage: usage}) do
+    usage.estimated_cost_cents >= max
   end
 end

--- a/lib/alloy/result.ex
+++ b/lib/alloy/result.ex
@@ -12,7 +12,7 @@ defmodule Alloy.Result do
     * `:usage` — accumulated `%Alloy.Usage{}` token counts
     * `:tool_calls` — list of tool execution metadata maps
     * `:metadata` — auxiliary result metadata such as provider-owned state
-    * `:status` — final run status (`:completed`, `:max_turns`, `:error`, `:halted`)
+    * `:status` — final run status (`:completed`, `:max_turns`, `:budget_exceeded`, `:error`, `:halted`)
     * `:turns` — number of agent loop iterations
     * `:error` — error term (or `nil` on success)
     * `:request_id` — correlation ID for async requests (or `nil` for sync)

--- a/test/alloy/agent/turn_test.exs
+++ b/test/alloy/agent/turn_test.exs
@@ -1835,4 +1835,74 @@ defmodule Alloy.Agent.TurnTest do
       assert result.status == :error
     end
   end
+
+  describe "run_loop/1 with max_budget_cents" do
+    test "halts when cost exceeds budget" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          # Turn 1: tool call — costs 50 cents
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"text" => "hello"}}
+          ]),
+          # Turn 2: would respond, but budget should be exceeded
+          TestProvider.text_response("Done!")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        max_budget_cents: 50
+      }
+
+      # Pre-seed usage so first turn pushes us over budget
+      state = State.init(config, [Message.user("Hi")])
+      state = %{state | usage: %Alloy.Usage{estimated_cost_cents: 51}}
+
+      result = Turn.run_loop(state)
+
+      assert result.status == :budget_exceeded
+      # Should stop before making any provider calls
+      assert result.turn == 0
+    end
+
+    test "allows run when under budget" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("Hello!")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        max_budget_cents: 100
+      }
+
+      state = State.init(config, [Message.user("Hi")])
+
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+    end
+
+    test "nil max_budget_cents means no limit" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("Hello!")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        max_budget_cents: nil
+      }
+
+      state = State.init(config, [Message.user("Hi")])
+      state = %{state | usage: %Alloy.Usage{estimated_cost_cents: 999_999}}
+
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `max_budget_cents` option to `Alloy.Agent.Config` — halts the agent loop with `:budget_exceeded` status when cumulative cost exceeds the threshold
- Check runs at the start of each turn, alongside the existing `max_turns` guard
- Default is `nil` (no limit), preserving existing behaviour

## Usage

```elixir
Alloy.run(input,
  provider: {Alloy.Provider.Anthropic, api_key: key, model: "claude-sonnet-4-20250514"},
  max_budget_cents: 50
)
# => %Result{status: :budget_exceeded} if cost exceeds 50 cents
```

## Test plan

- [x] 3 new tests: budget exceeded, under budget, nil = no limit
- [x] Full suite: 538 tests, 0 failures
- [x] `mix format`, `mix credo --strict`, `mix compile --warnings-as-errors` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)