### PR TITLE
release: 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-03-21
+
+### Added
+
+- **Cost guard** — `Alloy.run/2` now accepts `max_budget_cents: N` to cap agent spend. The loop halts with `:budget_exceeded` status when cumulative `estimated_cost_cents` exceeds the threshold. Default is `nil` (no limit).
+- **One-shot streaming helper** — `Alloy.stream/3` provides a simpler API for streaming agent responses without managing a GenServer.
+
+### Changed
+
+- **Summary-first context compaction** — `Alloy.Context.Compactor` now preserves the first message, keeps a recent token-budgeted verbatim window, and replaces older context with a single structured handoff summary generated through the configured provider. Falls back to deterministic truncation if summary generation fails.
+- **Grouped compaction settings** — `compaction: [reserve_tokens: N, keep_recent_tokens: N, fallback: :truncate]` makes context compaction behavior configurable.
+- **Reserve-based compaction trigger** — compaction now starts when the conversation exceeds `max_tokens - reserve_tokens` instead of the previous fixed 90% threshold.
+
+### Fixed
+
+- **Bash tool timeout** — fixed timeout override not being respected when passed via tool input.
+
 ## [0.7.6] - 2026-03-19
 
 ### Added
@@ -296,6 +313,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interactive REPL via `mix alloy`
 - Deterministic test provider for full TDD workflows
 
+[0.8.0]: https://github.com/alloy-ex/alloy/releases/tag/v0.8.0
+[0.7.6]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.6
 [0.7.5]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.5
 [0.7.4]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.4
 [0.7.3]: https://github.com/alloy-ex/alloy/releases/tag/v0.7.3

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alloy is the completion-tool-call loop and nothing else. Send messages to any LL
   tools: [Alloy.Tool.Core.Read]
 )
 
-result.text #=> "The version is 0.7.5"
+result.text #=> "The version is 0.8.0"
 ```
 
 ## Why Alloy?
@@ -28,7 +28,8 @@ Most agent frameworks try to be everything — sessions, memory, RAG, multi-agen
 - **Streaming** — token-by-token from any provider, unified interface
 - **Async dispatch** — `send_message/2` fires non-blocking, result arrives via PubSub
 - **Middleware** — custom hooks, tool blocking
-- **Context compaction** — automatic summarization when approaching token limits
+- **Context compaction** — summary-based compaction when approaching token limits, with configurable reserve and fallback to truncation
+- **Cost guard** — `max_budget_cents` halts the loop before overspending
 - **OTP-native** — supervision trees, hot code reloading, real parallel tool execution
 - **~5,000 lines** — small enough to read, understand, and extend
 
@@ -63,7 +64,7 @@ Add `alloy` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:alloy, "~> 0.7"}
+    {:alloy, "~> 0.8"}
   ]
 end
 ```
@@ -243,6 +244,25 @@ summarizes older context:
   ]
 )
 ```
+
+### Cost guard
+
+Cap how much an agent run can spend:
+
+```elixir
+{:ok, result} = Alloy.run("Research this codebase thoroughly",
+  provider: {Alloy.Provider.Anthropic, api_key: "...", model: "claude-sonnet-4-6"},
+  tools: [Alloy.Tool.Core.Read, Alloy.Tool.Core.Bash],
+  max_budget_cents: 50
+)
+
+case result.status do
+  :completed -> IO.puts(result.text)
+  :budget_exceeded -> IO.puts("Stopped: spent #{result.usage.estimated_cost_cents}¢")
+end
+```
+
+Set `max_budget_cents: nil` (default) for no limit.
 
 ### Supervised GenServer agent
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.7.6"
+  @version "0.8.0"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do


### PR DESCRIPTION
## Alloy 0.8.0

Version bump, changelog, and README updates for the 0.8.0 release.

### What's in this release (already on main via merged PRs)

- **Cost guard** (`max_budget_cents`) — halts the agent loop when spend exceeds threshold
- **One-shot streaming** (`Alloy.stream/3`) — simpler API for streaming without GenServer
- **Summary-based compaction** — structured handoff summaries replace naive truncation
- **Configurable compaction** — `compaction: [reserve_tokens:, keep_recent_tokens:, fallback:]`
- **Bash timeout fix** — timeout override now respected

### This PR adds

- Version bump: 0.7.6 → 0.8.0
- CHANGELOG entry for 0.8.0
- README: cost guard docs, updated version refs, improved compaction description

🤖 Generated with [Claude Code](https://claude.com/claude-code)