### PR TITLE
feat: support Gemini 3.x thought signatures in OpenAICompat

### DIFF
--- a/lib/alloy/provider/openai_compat.ex
+++ b/lib/alloy/provider/openai_compat.ex
@@ -154,7 +154,7 @@ defmodule Alloy.Provider.OpenAICompat do
       blocks
       |> Enum.filter(&(&1[:type] == "tool_use"))
       |> Enum.map(fn call ->
-        %{
+        tc = %{
           "id" => call.id,
           "type" => "function",
           "function" => %{
@@ -162,6 +162,12 @@ defmodule Alloy.Provider.OpenAICompat do
             "arguments" => Jason.encode!(call.input)
           }
         }
+
+        # Echo Gemini 3.x thought signatures back for multi-turn tool calls
+        case Map.get(call, :thought_signature) do
+          nil -> tc
+          sig -> Map.put(tc, "extra_content", %{"google" => %{"thought_signature" => sig}})
+        end
       end)
 
     text_parts =
@@ -273,9 +279,16 @@ defmodule Alloy.Provider.OpenAICompat do
       |> Enum.reduce_while([], fn tc, acc ->
         case Jason.decode(tc["function"]["arguments"]) do
           {:ok, input} ->
-            {:cont,
-             acc ++
-               [%{type: "tool_use", id: tc["id"], name: tc["function"]["name"], input: input}]}
+            block = %{type: "tool_use", id: tc["id"], name: tc["function"]["name"], input: input}
+
+            # Preserve Gemini 3.x thought signatures for multi-turn tool calls
+            block =
+              case get_in(tc, ["extra_content", "google", "thought_signature"]) do
+                nil -> block
+                sig -> Map.put(block, :thought_signature, sig)
+              end
+
+            {:cont, acc ++ [block]}
 
           {:error, _} ->
             {:halt, {:error, "Invalid JSON in tool call arguments for #{tc["function"]["name"]}"}}
@@ -292,6 +305,9 @@ defmodule Alloy.Provider.OpenAICompat do
   defp parse_finish_reason("tool_calls"), do: :tool_use
   defp parse_finish_reason(_), do: :end_turn
 
+  # Gemini 3.x wraps errors in a list
+  defp parse_error(status, [item | _]) when is_map(item), do: parse_error(status, item)
+
   defp parse_error(status, body) when is_binary(body) do
     case Jason.decode(body) do
       {:ok, %{"error" => error}} -> "#{error["type"]}: #{error["message"]}"
@@ -306,4 +322,6 @@ defmodule Alloy.Provider.OpenAICompat do
       _ -> "HTTP #{status}: #{inspect(body)}"
     end
   end
+
+  defp parse_error(_status, body), do: "API error: #{inspect(body)}"
 end


### PR DESCRIPTION
## Summary
- Gemini 3.x models (e.g. `gemini-3.1-pro-preview`) include `thought_signature` in tool call responses via `extra_content.google.thought_signature`
- These signatures **must** be echoed back in subsequent turns or the API returns a 400 error: `"Function call is missing a thought_signature in functionCall parts"`
- This PR preserves and echoes thought signatures through the multi-turn tool call loop

## Changes
- **Response parsing**: Capture `thought_signature` from `extra_content.google` on each tool call
- **Request formatting**: Echo `thought_signature` back in `extra_content` when formatting assistant messages with tool calls
- **Error handling**: Handle list-shaped error bodies from Gemini 3.x (was crashing `parse_error/2` with `FunctionClauseError`) + catch-all clause

## Backward compatibility
All changes are no-ops for providers that don't use thought signatures. Existing tests pass unchanged.

## Test plan
- [x] Verified with `gemini-3.1-pro-preview` — multi-turn tool calling works end-to-end
- [x] Verified `gemini-2.5-flash` and `gemini-2.5-pro` still work (no thought signatures, no-op path)
- [x] All 533 existing Alloy tests pass

## References
- [Gemini thought signatures docs](https://ai.google.dev/gemini-api/docs/thought-signatures)
- [Gemini OpenAI compatibility](https://ai.google.dev/gemini-api/docs/openai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)