### PR TITLE
feat: add Codex provider with ChatGPT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ result.text #=> "The version is 0.9.0"
 
 Most agent frameworks try to be everything — sessions, memory, RAG, multi-agent orchestration, scheduling, UI. Alloy does one thing well: the agent loop. Inspired by [Pi Agent](https://github.com/badlogic/pi-mono)'s minimalism, Alloy brings the same philosophy to the BEAM with OTP's natural advantages: supervision, fault isolation, parallel tool execution, and real concurrency.
 
-- **3 providers** — Anthropic, OpenAI, and OpenAICompat (works with any OpenAI-compatible API: Ollama, OpenRouter, xAI, DeepSeek, Mistral, Groq, Together, etc.)
+- **4 providers** — Anthropic, Codex, OpenAI, and OpenAICompat (works with any OpenAI-compatible API: Ollama, OpenRouter, xAI, DeepSeek, Mistral, Groq, Together, etc.)
 - **4 built-in tools** — read, write, edit, bash
 - **GenServer agents** — supervised, stateful, message-passing
 - **Streaming** — token-by-token from any provider, unified interface
@@ -113,6 +113,9 @@ Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.Anthropic, api_key: "..."
 
 # OpenAI
 Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAI, api_key: "...", model: "gpt-5.4"}} | opts])
+
+# Codex via local ChatGPT login
+Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.Codex, model: "gpt-5.4"}} | opts])
 
 # xAI via Responses-compatible API
 Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAI, api_key: "...", api_url: "https://api.x.ai", model: "grok-4"}} | opts])
@@ -400,11 +403,13 @@ end
 | Vendor | Recommended Module | Example Models |
 |--------|---------------------|----------------|
 | Anthropic | `Alloy.Provider.Anthropic` | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
+| Codex | `Alloy.Provider.Codex` | `gpt-5.4` via local `codex login` |
 | OpenAI | `Alloy.Provider.OpenAI` | `gpt-5.4` |
 | xAI | `Alloy.Provider.OpenAI` with `api_url: "https://api.x.ai"` | `grok-4`, `grok-4.1-fast`, `grok-4-fast-reasoning`, `grok-code-fast-1` |
 | Gemini | `Alloy.Provider.OpenAICompat` | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3-pro-preview` |
 | Other OpenAI-compatible APIs | `Alloy.Provider.OpenAICompat` | Ollama, OpenRouter, DeepSeek, Mistral, Groq, Together |
 
+Use `Alloy.Provider.Codex` to drive a locally installed Codex CLI with ChatGPT-plan auth.
 Use `Alloy.Provider.OpenAI` for native Responses APIs like OpenAI and xAI.
 Use `Alloy.Provider.OpenAICompat` for chat-completions compatible APIs and local runtimes.
 

--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -1,0 +1,488 @@
+defmodule Alloy.Provider.Codex do
+  @moduledoc """
+  Provider for ChatGPT-plan-backed Codex execution via `codex exec`.
+
+  This provider treats Codex as a structured completion backend rather than a
+  full agent runtime. Alloy remains responsible for the tool loop, while Codex
+  receives the current transcript and available tool definitions, then returns
+  JSON describing either a final assistant response or one or more tool calls.
+
+  ## Config
+
+  Required:
+  - `:model` - Codex model name (for example `"gpt-5.4"`)
+
+  Optional:
+  - `:codex_bin` - Executable path (default: `"codex"`)
+  - `:workdir` - Directory passed to `codex exec` (defaults to a temp dir)
+  - `:profile` - Optional Codex config profile
+  - `:codex_home` - Override `CODEX_HOME` instead of creating an isolated temp home
+  - `:command_runner` - Test hook matching `System.cmd/3`
+  - `:system_prompt` - System prompt string
+
+  ## Notes
+
+  - Authentication is handled by the local `codex` CLI login state.
+  - By default the provider creates a minimal temporary `CODEX_HOME` containing
+    only `auth.json`, which avoids pulling in the user's full MCP/plugin config.
+  - Usage accounting is not exposed by `codex exec` in a structured form yet,
+    so this provider currently reports zero token counts.
+  - Streaming is emulated by running a normal completion and replaying the final
+    text to the provided callback.
+  """
+
+  @behaviour Alloy.Provider
+
+  alias Alloy.Message
+
+  @impl true
+  def complete(messages, tool_defs, config) do
+    case prepare_paths(config) do
+      {:ok, paths} ->
+        try do
+          with :ok <- File.write(paths.schema_path, Jason.encode!(response_schema())),
+               prompt = build_prompt(messages, tool_defs, config),
+               {:ok, command_result} <- run_codex(prompt, paths, config),
+               {:ok, payload} <- read_payload_or_error(paths.last_message_path, command_result) do
+            parse_payload(payload, config, command_result)
+          end
+        after
+          cleanup_paths(paths)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def stream(messages, tool_defs, config, on_chunk) when is_function(on_chunk, 1) do
+    with {:ok, result} <- complete(messages, tool_defs, config),
+         :ok <- emit_chunks(result, on_chunk) do
+      {:ok, result}
+    end
+  end
+
+  defp prepare_paths(config) do
+    base_dir =
+      config
+      |> Map.get(:tmp_dir)
+      |> case do
+        nil -> Path.join(System.tmp_dir!(), "alloy-codex-#{System.unique_integer([:positive])}")
+        dir -> Path.join(dir, "alloy-codex-#{System.unique_integer([:positive])}")
+      end
+
+    case File.mkdir_p(base_dir) do
+      :ok ->
+        with {:ok, codex_home} <- prepare_codex_home(base_dir, config) do
+          {:ok,
+           %{
+             base_dir: base_dir,
+             codex_home: codex_home,
+             schema_path: Path.join(base_dir, "response_schema.json"),
+             last_message_path: Path.join(base_dir, "last_message.json"),
+             workdir: Map.get(config, :workdir, base_dir)
+           }}
+        end
+
+      {:error, reason} ->
+        {:error, "failed to prepare Codex temp directory: #{inspect(reason)}"}
+    end
+  end
+
+  defp cleanup_paths(%{base_dir: base_dir}) do
+    File.rm_rf(base_dir)
+    :ok
+  end
+
+  defp prepare_codex_home(_base_dir, %{command_runner: _runner}) do
+    {:ok, nil}
+  end
+
+  defp prepare_codex_home(_base_dir, %{codex_home: codex_home}) when is_binary(codex_home) do
+    {:ok, codex_home}
+  end
+
+  defp prepare_codex_home(base_dir, config) do
+    codex_home = Path.join(base_dir, "codex-home")
+    auth_source = Map.get(config, :auth_path, default_auth_path())
+
+    with :ok <- File.mkdir_p(codex_home),
+         :ok <- copy_file(auth_source, Path.join(codex_home, "auth.json")) do
+      maybe_copy_config(codex_home, config)
+    end
+  end
+
+  defp run_codex(prompt, paths, config) do
+    runner = Map.get(config, :command_runner, &System.cmd/3)
+    executable = Map.get(config, :codex_bin, "codex")
+
+    args =
+      [
+        "exec",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "--sandbox",
+        "read-only",
+        "--output-schema",
+        paths.schema_path,
+        "--output-last-message",
+        paths.last_message_path
+      ]
+      |> maybe_append_profile(config)
+      |> maybe_append_model(config)
+      |> Kernel.++([prompt])
+
+    {command, command_args, command_opts} =
+      runner_command(runner, executable, args, paths, config)
+
+    case runner.(command, command_args, command_opts) do
+      {output, status} when is_integer(status) ->
+        {:ok, %{output: output, status: status}}
+    end
+  rescue
+    error in ErlangError ->
+      {:error, "codex exec failed to start: #{Exception.message(error)}"}
+  end
+
+  defp runner_command(runner, executable, args, paths, config) do
+    opts = [cd: paths.workdir, stderr_to_stdout: true]
+
+    if injected_runner?(runner, config) do
+      {executable, args, opts}
+    else
+      env_args =
+        [{"OTEL_SDK_DISABLED", "true"}, {"CODEX_HOME", paths.codex_home}]
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Enum.map_join(" ", fn {key, value} -> shell_escape("#{key}=#{value}") end)
+
+      shell_command =
+        "env " <>
+          env_args <>
+          " " <>
+          Enum.map_join([executable | args], " ", fn arg -> shell_escape(arg) end) <>
+          " </dev/null"
+
+      {"/bin/sh", ["-lc", shell_command], opts}
+    end
+  end
+
+  defp injected_runner?(runner, config) do
+    Map.has_key?(config, :command_runner) and runner != (&System.cmd/3)
+  end
+
+  defp codex_error(status, output) do
+    message =
+      output
+      |> String.trim()
+      |> truncate(2000)
+
+    "codex exec failed with status #{status}: #{message}"
+  end
+
+  defp read_payload_or_error(path, %{status: status, output: output}) do
+    case read_payload(path) do
+      {:ok, payload} ->
+        {:ok, payload}
+
+      {:error, reason} when status == 0 ->
+        {:error, reason}
+
+      {:error, _reason} ->
+        {:error, codex_error(status, output)}
+    end
+  end
+
+  defp read_payload(path) do
+    with {:ok, content} <- File.read(path),
+         {:ok, payload} <- Jason.decode(content) do
+      {:ok, payload}
+    else
+      {:error, reason} when is_atom(reason) ->
+        {:error, "failed to read Codex response file: #{inspect(reason)}"}
+
+      {:error, %Jason.DecodeError{} = error} ->
+        {:error, "failed to decode Codex response JSON: #{Exception.message(error)}"}
+    end
+  end
+
+  defp parse_payload(
+         %{"stop_reason" => "end_turn", "text" => text, "tool_calls" => tool_calls},
+         config,
+         command_result
+       )
+       when is_binary(text) and is_list(tool_calls) do
+    if tool_calls == [] do
+      {:ok,
+       %{
+         stop_reason: :end_turn,
+         messages: [Message.assistant(text)],
+         usage: zero_usage(),
+         response_metadata: response_metadata(config, command_result)
+       }}
+    else
+      {:error, "Codex returned tool_calls for an end_turn response"}
+    end
+  end
+
+  defp parse_payload(
+         %{"stop_reason" => "tool_use", "text" => text, "tool_calls" => tool_calls},
+         config,
+         command_result
+       )
+       when is_binary(text) and is_list(tool_calls) do
+    with {:ok, blocks} <- parse_tool_blocks(text, tool_calls) do
+      {:ok,
+       %{
+         stop_reason: :tool_use,
+         messages: [Message.assistant_blocks(blocks)],
+         usage: zero_usage(),
+         response_metadata: response_metadata(config, command_result)
+       }}
+    end
+  end
+
+  defp parse_payload(payload, _config, _command_result) do
+    {:error, "unexpected Codex response payload: #{inspect(payload)}"}
+  end
+
+  defp parse_tool_blocks(text, tool_calls) do
+    blocks =
+      tool_calls
+      |> Enum.with_index(1)
+      |> Enum.map(fn {tool_call, index} ->
+        with {:ok, call_id} <- tool_call_id(tool_call, index),
+             {:ok, name} <- fetch_string(tool_call, "name"),
+             {:ok, arguments} <- fetch_arguments(tool_call) do
+          {:ok, %{type: "tool_use", id: call_id, name: name, input: arguments}}
+        end
+      end)
+
+    case Enum.find(blocks, &match?({:error, _}, &1)) do
+      {:error, reason} ->
+        {:error, reason}
+
+      nil ->
+        tool_blocks = Enum.map(blocks, fn {:ok, block} -> block end)
+
+        full_blocks =
+          case String.trim(text) do
+            "" -> tool_blocks
+            trimmed -> [%{type: "text", text: trimmed} | tool_blocks]
+          end
+
+        if full_blocks == [] do
+          {:error, "Codex returned tool_use without any tool calls"}
+        else
+          {:ok, full_blocks}
+        end
+    end
+  end
+
+  defp tool_call_id(tool_call, index) do
+    case Map.get(tool_call, "call_id") do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      nil -> {:ok, "call_#{index}"}
+      other -> {:error, "invalid Codex tool call id: #{inspect(other)}"}
+    end
+  end
+
+  defp fetch_string(map, key) do
+    case Map.get(map, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      other -> {:error, "invalid Codex field #{inspect(key)}: #{inspect(other)}"}
+    end
+  end
+
+  defp fetch_arguments(map) do
+    with {:ok, json} <- fetch_string(map, "arguments_json"),
+         {:ok, decoded} <- Jason.decode(json),
+         true <- is_map(decoded) do
+      {:ok, decoded}
+    else
+      false ->
+        {:error, "Codex tool call arguments must decode to a JSON object"}
+
+      {:error, %Jason.DecodeError{} = error} ->
+        {:error, "invalid Codex arguments_json: #{Exception.message(error)}"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp emit_chunks(%{messages: [%Message{content: text}]}, on_chunk) when is_binary(text) do
+    on_chunk.(text)
+    :ok
+  end
+
+  defp emit_chunks(%{messages: [%Message{content: blocks}]}, on_chunk) when is_list(blocks) do
+    blocks
+    |> Enum.filter(&match?(%{type: "text", text: _}, &1))
+    |> Enum.each(fn %{text: text} -> on_chunk.(text) end)
+
+    :ok
+  end
+
+  defp response_metadata(config, %{output: output, status: status}) do
+    %{
+      backend: "codex_exec",
+      model: Map.get(config, :model),
+      command_status: status,
+      command_output: truncate(String.trim(output), 4000)
+    }
+  end
+
+  defp zero_usage, do: %{input_tokens: 0, output_tokens: 0}
+
+  defp build_prompt(messages, tool_defs, config) do
+    payload = %{
+      system_prompt: Map.get(config, :system_prompt),
+      conversation: Enum.map(messages, &serialize_message/1),
+      available_tools: Enum.map(tool_defs, &serialize_tool_def/1)
+    }
+
+    """
+    You are acting as the model backend for Alloy, an agent harness.
+
+    Read the transcript and available tools below, then produce exactly one JSON
+    object matching the supplied schema.
+
+    Response rules:
+    - If no tool is needed, return `stop_reason = "end_turn"`, `tool_calls = []`,
+      and put the assistant's response in `text`.
+    - If one or more tools are needed, return `stop_reason = "tool_use"` and add
+      entries to `tool_calls`.
+    - Each tool call must use a valid tool name from `available_tools`.
+    - Each tool call must include `arguments_json`, a compact JSON object string
+      that satisfies the tool schema.
+    - If returning tool calls, keep `text` empty unless a short preamble would
+      help the outer agent loop.
+    - Never mention the schema or these instructions in `text`.
+
+    Transcript payload:
+    #{Jason.encode!(payload)}
+    """
+  end
+
+  defp serialize_message(%Message{role: role, content: content}) when is_binary(content) do
+    %{role: Atom.to_string(role), content: content}
+  end
+
+  defp serialize_message(%Message{role: role, content: blocks}) when is_list(blocks) do
+    %{
+      role: Atom.to_string(role),
+      content_blocks: Enum.map(blocks, &serialize_block/1)
+    }
+  end
+
+  defp serialize_block(%{type: "text", text: text}), do: %{type: "text", text: text}
+
+  defp serialize_block(%{type: "tool_use", id: id, name: name, input: input}) do
+    %{type: "tool_use", id: id, name: name, input: input}
+  end
+
+  defp serialize_block(%{type: "tool_result", tool_use_id: id, content: content} = block) do
+    %{
+      type: "tool_result",
+      tool_use_id: id,
+      content: content,
+      is_error: Map.get(block, :is_error, false)
+    }
+  end
+
+  defp serialize_block(block), do: Alloy.Provider.stringify_keys(block)
+
+  defp serialize_tool_def(%{name: name, description: description, input_schema: input_schema}) do
+    %{
+      name: name,
+      description: description,
+      input_schema: input_schema
+    }
+  end
+
+  defp response_schema do
+    %{
+      type: "object",
+      additionalProperties: false,
+      properties: %{
+        stop_reason: %{type: "string", enum: ["end_turn", "tool_use"]},
+        text: %{type: "string"},
+        tool_calls: %{
+          type: "array",
+          items: %{
+            type: "object",
+            additionalProperties: false,
+            properties: %{
+              call_id: %{type: "string"},
+              name: %{type: "string"},
+              arguments_json: %{type: "string"}
+            },
+            required: ["call_id", "name", "arguments_json"]
+          }
+        }
+      },
+      required: ["stop_reason", "text", "tool_calls"]
+    }
+  end
+
+  defp maybe_append_profile(args, config) do
+    case Map.get(config, :profile) do
+      nil -> args
+      profile -> args ++ ["--profile", profile]
+    end
+  end
+
+  defp maybe_append_model(args, config) do
+    case Map.get(config, :model) do
+      nil -> args
+      model -> args ++ ["--model", model]
+    end
+  end
+
+  defp shell_escape(value) when is_binary(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
+
+  defp copy_file(source, destination) do
+    case File.cp(source, destination) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, "failed to copy #{Path.basename(source)} into Codex home: #{inspect(reason)}"}
+    end
+  end
+
+  defp maybe_copy_config(codex_home, %{profile: profile})
+       when is_binary(profile) and profile != "" do
+    config_source = default_config_path()
+
+    case File.exists?(config_source) do
+      true ->
+        case File.cp(config_source, Path.join(codex_home, "config.toml")) do
+          :ok -> {:ok, codex_home}
+          {:error, reason} -> {:error, "failed to copy Codex config: #{inspect(reason)}"}
+        end
+
+      false ->
+        {:error, "missing ~/.codex/config.toml required for Codex profile #{inspect(profile)}"}
+    end
+  end
+
+  defp maybe_copy_config(codex_home, _config), do: {:ok, codex_home}
+
+  defp default_auth_path do
+    Path.join(System.user_home!(), ".codex/auth.json")
+  end
+
+  defp default_config_path do
+    Path.join(System.user_home!(), ".codex/config.toml")
+  end
+
+  defp truncate(text, limit) when is_binary(text) and byte_size(text) > limit do
+    binary_part(text, 0, limit) <> "..."
+  end
+
+  defp truncate(text, _limit), do: text
+end

--- a/mix.exs
+++ b/mix.exs
@@ -75,6 +75,7 @@ defmodule Alloy.MixProject do
         Providers: [
           Alloy.Provider,
           Alloy.Provider.Anthropic,
+          Alloy.Provider.Codex,
           Alloy.Provider.OpenAI,
           Alloy.Provider.OpenAICompat,
           Alloy.Provider.Retry,

--- a/test/alloy/provider/codex_test.exs
+++ b/test/alloy/provider/codex_test.exs
@@ -1,0 +1,231 @@
+defmodule Alloy.Provider.CodexTest do
+  use ExUnit.Case, async: true
+
+  alias Alloy.Message
+  alias Alloy.Provider.Codex
+
+  describe "complete/3" do
+    test "returns an end_turn assistant message from Codex JSON output" do
+      config = %{
+        model: "gpt-5.4",
+        command_runner:
+          fake_runner(fn _args, _opts, output_path ->
+            File.write!(
+              output_path,
+              ~s({"stop_reason":"end_turn","text":"All done","tool_calls":[]})
+            )
+
+            "codex\n{\"stop_reason\":\"end_turn\"}\n"
+          end)
+      }
+
+      assert {:ok, result} = Codex.complete([Message.user("Hi")], [], config)
+      assert result.stop_reason == :end_turn
+      assert result.messages == [Message.assistant("All done")]
+      assert result.usage == %{input_tokens: 0, output_tokens: 0}
+      assert result.response_metadata.backend == "codex_exec"
+      assert result.response_metadata.model == "gpt-5.4"
+      assert result.response_metadata.command_status == 0
+    end
+
+    test "returns tool_use blocks when Codex requests tools" do
+      tool_defs = [
+        %{
+          name: "search_examples",
+          description: "Find similar inbox examples",
+          input_schema: %{type: "object", properties: %{query: %{type: "string"}}}
+        }
+      ]
+
+      config = %{
+        model: "gpt-5.4",
+        command_runner:
+          fake_runner(fn _args, _opts, output_path ->
+            payload = %{
+              stop_reason: "tool_use",
+              text: "",
+              tool_calls: [
+                %{
+                  call_id: "call_1",
+                  name: "search_examples",
+                  arguments_json: ~s({"query":"waiting on vendor","limit":2})
+                }
+              ]
+            }
+
+            File.write!(output_path, Jason.encode!(payload))
+            "codex\n#{Jason.encode!(payload)}\n"
+          end)
+      }
+
+      assert {:ok, result} =
+               Codex.complete([Message.user("Help me triage this")], tool_defs, config)
+
+      assert result.stop_reason == :tool_use
+
+      assert result.messages == [
+               Message.assistant_blocks([
+                 %{
+                   type: "tool_use",
+                   id: "call_1",
+                   name: "search_examples",
+                   input: %{"query" => "waiting on vendor", "limit" => 2}
+                 }
+               ])
+             ]
+    end
+
+    test "builds a structured prompt that includes system prompt and tool definitions" do
+      parent = self()
+
+      config = %{
+        model: "gpt-5.4",
+        system_prompt: "You are an inbox triage harness.",
+        command_runner:
+          fake_runner(fn args, _opts, output_path ->
+            send(parent, {:codex_args, args})
+            File.write!(output_path, ~s({"stop_reason":"end_turn","text":"OK","tool_calls":[]}))
+            "codex\n{\"stop_reason\":\"end_turn\"}\n"
+          end)
+      }
+
+      tool_defs = [
+        %{
+          name: "search_examples",
+          description: "Find similar inbox examples",
+          input_schema: %{type: "object", properties: %{query: %{type: "string"}}}
+        }
+      ]
+
+      messages = [
+        Message.user("Need a decision"),
+        Message.assistant_blocks([
+          %{
+            type: "tool_use",
+            id: "call_1",
+            name: "search_examples",
+            input: %{"query" => "urgent"}
+          },
+          %{type: "text", text: "Checking similar examples."}
+        ]),
+        Message.tool_results([
+          %{type: "tool_result", tool_use_id: "call_1", content: "Found two examples"}
+        ])
+      ]
+
+      assert {:ok, _result} = Codex.complete(messages, tool_defs, config)
+
+      assert_receive {:codex_args, args}
+      prompt = List.last(args)
+
+      assert prompt =~ "You are acting as the model backend for Alloy"
+      assert prompt =~ "You are an inbox triage harness."
+      assert prompt =~ "\"name\":\"search_examples\""
+      assert prompt =~ "\"tool_result\""
+      assert prompt =~ "\"Found two examples\""
+    end
+
+    test "returns a helpful error when Codex output violates the contract" do
+      config = %{
+        model: "gpt-5.4",
+        command_runner:
+          fake_runner(fn _args, _opts, output_path ->
+            File.write!(
+              output_path,
+              ~s({"stop_reason":"end_turn","text":"oops","tool_calls":[{"call_id":"call_1","name":"bad","arguments":{}}]})
+            )
+
+            "codex\n{\"stop_reason\":\"end_turn\"}\n"
+          end)
+      }
+
+      assert {:error, reason} = Codex.complete([Message.user("Hi")], [], config)
+      assert reason =~ "tool_calls"
+    end
+
+    test "returns a helpful error when arguments_json is not valid JSON" do
+      config = %{
+        model: "gpt-5.4",
+        command_runner:
+          fake_runner(fn _args, _opts, output_path ->
+            payload = %{
+              stop_reason: "tool_use",
+              text: "",
+              tool_calls: [
+                %{call_id: "call_1", name: "search_examples", arguments_json: "{not json}"}
+              ]
+            }
+
+            File.write!(output_path, Jason.encode!(payload))
+            "codex\n#{Jason.encode!(payload)}\n"
+          end)
+      }
+
+      assert {:error, reason} = Codex.complete([Message.user("Hi")], [], config)
+      assert reason =~ "arguments_json"
+    end
+
+    test "accepts a parsed payload even if codex exits non-zero" do
+      config = %{
+        model: "gpt-5.4",
+        command_runner:
+          fake_runner(fn _args, _opts, output_path ->
+            File.write!(
+              output_path,
+              ~s({"stop_reason":"end_turn","text":"Recovered","tool_calls":[]})
+            )
+
+            {"codex noise on stderr", 1}
+          end)
+      }
+
+      assert {:ok, result} = Codex.complete([Message.user("Hi")], [], config)
+      assert result.messages == [Message.assistant("Recovered")]
+      assert result.response_metadata.command_status == 1
+    end
+  end
+
+  describe "stream/4" do
+    test "replays the final assistant text through the callback" do
+      parent = self()
+
+      config = %{
+        model: "gpt-5.4",
+        command_runner:
+          fake_runner(fn _args, _opts, output_path ->
+            File.write!(
+              output_path,
+              ~s({"stop_reason":"end_turn","text":"Chunk me","tool_calls":[]})
+            )
+
+            "codex\n{\"stop_reason\":\"end_turn\"}\n"
+          end)
+      }
+
+      assert {:ok, result} =
+               Codex.stream([Message.user("Hi")], [], config, fn chunk ->
+                 send(parent, {:chunk, chunk})
+                 :ok
+               end)
+
+      assert_receive {:chunk, "Chunk me"}
+      assert result.messages == [Message.assistant("Chunk me")]
+    end
+  end
+
+  defp fake_runner(fun) do
+    fn _cmd, args, opts ->
+      output_path = output_path!(args)
+
+      case fun.(args, opts, output_path) do
+        {output, status} when is_binary(output) and is_integer(status) -> {output, status}
+        output when is_binary(output) -> {output, 0}
+      end
+    end
+  end
+
+  defp output_path!(args) do
+    index = Enum.find_index(args, &(&1 == "--output-last-message"))
+    Enum.at(args, index + 1)
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Alloy.Provider.Codex`, a provider adapter that lets Alloy run against a locally authenticated `codex` CLI session backed by a ChatGPT plan.

This keeps Alloy's existing tool loop in control and treats Codex as a structured completion backend:

- serializes the current transcript and available tool definitions into a constrained prompt
- asks Codex to return a single schema-validated JSON payload
- converts tool requests back into Alloy `tool_use` blocks
- isolates `CODEX_HOME` by default so user MCP/plugin config does not leak into eval runs

## Notes

- Authentication comes from local `codex login`
- usage is currently reported as zero because `codex exec` does not expose structured token counts for us yet
- streaming is implemented by replaying the final assistant text through Alloy's stream callback

## Verification

- `mix test`
- `mix test test/alloy/provider/codex_test.exs`
- `mix run -e 'alias Alloy.Provider.Codex; alias Alloy.Message; IO.inspect(Codex.complete([Message.user("Reply with OK")], [], %{model: "gpt-5.4"}))'`

