### PR TITLE
feat: add halt_on_tool option to Alloy.run/2

### DIFF
--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -73,6 +73,23 @@ defmodule Alloy do
   or ignored if `:messages` option provides conversation history.
 
   Returns `{:ok, result}` on completion or `{:error, result}` on failure.
+
+  ## Options
+
+    - `:halt_on_tool` — `tool_name` string or `{tool_name, action}` tuple. When
+      any executed tool matches, the loop halts immediately after that tool's result
+      without giving the LLM another turn. Default: `nil`.
+
+      ```elixir
+      # Halt after any call to the "beads" tool
+      Alloy.run(prompt, halt_on_tool: "beads", ...)
+
+      # Halt only after beads tool with action="transition"
+      Alloy.run(prompt, halt_on_tool: {"beads", "transition"}, ...)
+      ```
+
+      This prevents agents from producing a final narration turn after a completion
+      signal. The result has `status: :halted` and `error: "halt_on_tool: ..."`.
   """
   @spec run(String.t() | nil, keyword()) :: {:ok, result()} | {:error, result()}
   def run(message \\ nil, opts) do

--- a/lib/alloy/agent/config.ex
+++ b/lib/alloy/agent/config.ex
@@ -23,7 +23,8 @@ defmodule Alloy.Agent.Config do
           context_discovery: boolean(),
           on_shutdown: (Alloy.Session.t() -> any()) | nil,
           pubsub: module() | nil,
-          subscribe: [String.t()]
+          subscribe: [String.t()],
+          halt_on_tool: {String.t(), String.t()} | String.t() | nil
         }
 
   @enforce_keys [:provider, :provider_config]
@@ -44,7 +45,8 @@ defmodule Alloy.Agent.Config do
     context_discovery: false,
     on_shutdown: nil,
     pubsub: nil,
-    subscribe: []
+    subscribe: [],
+    halt_on_tool: nil
   ]
 
   @doc """
@@ -91,7 +93,8 @@ defmodule Alloy.Agent.Config do
       context_discovery: context_discovery,
       on_shutdown: Keyword.get(opts, :on_shutdown, nil),
       pubsub: Keyword.get(opts, :pubsub, nil),
-      subscribe: Keyword.get(opts, :subscribe, [])
+      subscribe: Keyword.get(opts, :subscribe, []),
+      halt_on_tool: Keyword.get(opts, :halt_on_tool, nil)
     }
   end
 

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -135,15 +135,32 @@ defmodule Alloy.Agent.Turn do
           result_msg ->
             state = State.append_messages(state, result_msg)
 
-            case Middleware.run(:after_tool_execution, state) do
-              {:halted, reason} ->
-                %{state | status: :halted, error: "Halted by middleware: #{reason}"}
+            if halt_on_tool_match?(tool_calls, state.config.halt_on_tool) do
+              %{state | status: :halted, error: "halt_on_tool: loop halted after matching tool"}
+            else
+              case Middleware.run(:after_tool_execution, state) do
+                {:halted, reason} ->
+                  %{state | status: :halted, error: "Halted by middleware: #{reason}"}
 
-              %State{} = state ->
-                do_turn(state, opts, deadline)
+                %State{} = state ->
+                  do_turn(state, opts, deadline)
+              end
             end
         end
     end
+  end
+
+  defp halt_on_tool_match?(_tool_calls, nil), do: false
+
+  defp halt_on_tool_match?(tool_calls, {tool_name, action})
+       when is_binary(tool_name) and is_binary(action) do
+    Enum.any?(tool_calls, fn tc ->
+      tc[:name] == tool_name and (tc[:input] || %{})["action"] == action
+    end)
+  end
+
+  defp halt_on_tool_match?(tool_calls, tool_name) when is_binary(tool_name) do
+    Enum.any?(tool_calls, fn tc -> tc[:name] == tool_name end)
   end
 
   defp call_provider_with_retry(state, provider, provider_config, streaming?, on_chunk, deadline) do

--- a/test/alloy/agent/turn_test.exs
+++ b/test/alloy/agent/turn_test.exs
@@ -1365,4 +1365,99 @@ defmodule Alloy.Agent.TurnTest do
       assert receive_timeout <= 4_000
     end
   end
+
+  describe "run_loop/2 halt_on_tool" do
+    test "halts after matching tool name without giving LLM another turn" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"text" => "done"}}
+          ]),
+          # This response should NEVER be reached — halt_on_tool fires first
+          TestProvider.text_response("This narration should not appear")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: "echo"
+      }
+
+      state = State.init(config, [Message.user("Echo done")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :halted
+      assert result.error =~ "halt_on_tool"
+      # Only 1 provider turn fired (tool_use), not 2
+      assert result.turn == 1
+    end
+
+    test "halts after matching tool name and action tuple" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"action" => "close", "text" => "bye"}}
+          ]),
+          TestProvider.text_response("Should not reach here")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: {"echo", "close"}
+      }
+
+      state = State.init(config, [Message.user("Close")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :halted
+      assert result.error =~ "halt_on_tool"
+    end
+
+    test "does not halt when tool name matches but action does not" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"action" => "create", "text" => "hi"}}
+          ]),
+          TestProvider.text_response("Completed normally")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: {"echo", "close"}
+      }
+
+      state = State.init(config, [Message.user("Create")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+    end
+
+    test "does not halt when halt_on_tool is nil" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"text" => "hello"}}
+          ]),
+          TestProvider.text_response("Done")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: nil
+      }
+
+      state = State.init(config, [Message.user("Go")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Agents that use tool calls to signal completion (e.g. transitioning a bead) always get a final text turn after their last tool result. This is structural — Alloy's loop ends with an unconstrained LLM response after tool results are processed:

```
turn N:   agent calls beads.transition → result returned to LLM
turn N+1: LLM produces a text response with no tool calls ← narration lives here
loop ends
```

No system-prompt instruction prevents this reliably. The loop architecture guarantees it happens.

## Solution

Add a first-class `halt_on_tool:` option to `Alloy.run/2` so the loop halts immediately after a specified tool executes, without requiring custom middleware.

```elixir
# Halt after any call to the "beads" tool
Alloy.run(prompt, halt_on_tool: "beads", ...)

# Halt only after beads tool with action="transition"  
Alloy.run(prompt, halt_on_tool: {"beads", "transition"}, ...)
```

The result has `status: :halted` and `error: "halt_on_tool: ..."`.

## Changes

- `Config`: new `halt_on_tool` field (string or `{tool_name, action}` tuple, default `nil`)
- `Turn.handle_tool_use/4`: checks `halt_on_tool` after tool execution, before giving the LLM another turn
- `Alloy.run/2` docs: documents the new option with examples
- 4 new tests covering: name-only match, name+action match, non-matching action (no halt), nil (no halt)

## Note

The `:halt, reason` mechanism already exists in middleware — this PR adds a convenience option so users don't need custom middleware to access it. The change is surgical (29 lines added to turn.ex).