### PR TITLE
feat: add halt_on_tool option to Alloy.run/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`halt_on_tool:` option for `Alloy.run/2`** — pass `halt_on_tool: "tool_name"` or
+  `halt_on_tool: {"tool_name", "action"}` to stop the agent loop immediately after a
+  matching tool executes, before the LLM gets another turn. This prevents agents from
+  producing a final narration turn after a completion signal (e.g. transitioning a bead
+  or calling a "done" tool). Equivalent to writing a one-liner `:after_tool_execution`
+  middleware, but built in. Default: `nil` (no early halt).
+
 ## [0.9.0] - 2026-03-22
 
 ### Breaking

--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -51,6 +51,8 @@ defmodule Alloy do
   - `:context` - arbitrary map passed to tools and middleware (default: `%{}`)
   - `:max_pending` - max queued async `send_message/3` requests while one is running (default: `0`)
   - `:model_metadata_overrides` - overrides for model context windows used to derive `:max_tokens` when not set explicitly (default: `%{}`)
+  - `:halt_on_tool` - `tool_name` string or `{tool_name, action}` tuple; halts the loop
+    immediately after a matching tool executes, without an extra LLM turn (default: `nil`)
   """
 
   alias Alloy.Agent.{Config, Server, State, Turn}

--- a/lib/alloy/agent/config.ex
+++ b/lib/alloy/agent/config.ex
@@ -42,7 +42,8 @@ defmodule Alloy.Agent.Config do
           fallback_providers: [{module(), map()}],
           code_execution: boolean(),
           model_metadata_overrides: map(),
-          max_budget_cents: number() | nil
+          max_budget_cents: number() | nil,
+          halt_on_tool: {String.t(), String.t()} | String.t() | nil
         }
 
   @enforce_keys [:provider, :provider_config]
@@ -71,7 +72,8 @@ defmodule Alloy.Agent.Config do
     fallback_providers: [],
     code_execution: false,
     model_metadata_overrides: %{},
-    max_budget_cents: nil
+    max_budget_cents: nil,
+    halt_on_tool: nil
   ]
 
   @doc """
@@ -122,7 +124,8 @@ defmodule Alloy.Agent.Config do
         |> Enum.map(&parse_fallback_provider/1),
       code_execution: Keyword.get(opts, :code_execution, false),
       model_metadata_overrides: model_metadata_overrides,
-      max_budget_cents: Keyword.get(opts, :max_budget_cents)
+      max_budget_cents: Keyword.get(opts, :max_budget_cents),
+      halt_on_tool: Keyword.get(opts, :halt_on_tool, nil)
     }
   end
 

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -242,15 +242,36 @@ defmodule Alloy.Agent.Turn do
               |> State.append_messages(result_msg)
               |> State.append_tool_calls(tool_call_meta)
 
-            case Middleware.run(:after_tool_execution, state) do
-              {:halted, reason} ->
-                %{state | status: :halted, error: "Halted by middleware: #{reason}"}
-
-              %State{} = state ->
-                do_turn(state, opts, deadline)
-            end
+            after_tools(state, tool_calls, opts, deadline)
         end
     end
+  end
+
+  defp after_tools(%State{} = state, tool_calls, opts, deadline) do
+    if halt_on_tool_match?(tool_calls, state.config.halt_on_tool) do
+      %{state | status: :halted, error: "halt_on_tool: loop halted after matching tool"}
+    else
+      case Middleware.run(:after_tool_execution, state) do
+        {:halted, reason} ->
+          %{state | status: :halted, error: "Halted by middleware: #{reason}"}
+
+        %State{} = state ->
+          do_turn(state, opts, deadline)
+      end
+    end
+  end
+
+  defp halt_on_tool_match?(_tool_calls, nil), do: false
+
+  defp halt_on_tool_match?(tool_calls, {tool_name, action})
+       when is_binary(tool_name) and is_binary(action) do
+    Enum.any?(tool_calls, fn tc ->
+      tc[:name] == tool_name and (tc[:input] || %{})["action"] == action
+    end)
+  end
+
+  defp halt_on_tool_match?(tool_calls, tool_name) when is_binary(tool_name) do
+    Enum.any?(tool_calls, fn tc -> tc[:name] == tool_name end)
   end
 
   defp build_provider_config(%State{config: config, provider_state: provider_state}) do

--- a/test/alloy/agent/turn_test.exs
+++ b/test/alloy/agent/turn_test.exs
@@ -2111,4 +2111,99 @@ defmodule Alloy.Agent.TurnTest do
       assert is_integer(measurements.messages_after)
     end
   end
+
+  describe "run_loop/2 halt_on_tool" do
+    test "halts after matching tool name without giving LLM another turn" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"text" => "done"}}
+          ]),
+          # This response should NEVER be reached — halt_on_tool fires first
+          TestProvider.text_response("This narration should not appear")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: "echo"
+      }
+
+      state = State.init(config, [Message.user("Echo done")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :halted
+      assert result.error =~ "halt_on_tool"
+      # Only 1 provider turn fired (tool_use), not 2
+      assert result.turn == 1
+    end
+
+    test "halts after matching tool name and action tuple" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"action" => "close", "text" => "bye"}}
+          ]),
+          TestProvider.text_response("Should not reach here")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: {"echo", "close"}
+      }
+
+      state = State.init(config, [Message.user("Close")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :halted
+      assert result.error =~ "halt_on_tool"
+    end
+
+    test "does not halt when tool name matches but action does not" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"action" => "create", "text" => "hi"}}
+          ]),
+          TestProvider.text_response("Completed normally")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: {"echo", "close"}
+      }
+
+      state = State.init(config, [Message.user("Create")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+    end
+
+    test "does not halt when halt_on_tool is nil" do
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.tool_use_response([
+            %{id: "tool_1", name: "echo", input: %{"text" => "hello"}}
+          ]),
+          TestProvider.text_response("Done")
+        ])
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        tools: [EchoTool],
+        halt_on_tool: nil
+      }
+
+      state = State.init(config, [Message.user("Go")])
+      result = Turn.run_loop(state)
+
+      assert result.status == :completed
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Agents that use tool calls to signal completion always get a final LLM turn after their last tool result. This is structural — Alloy's loop ends with an unconstrained LLM response after tool results are processed:

```
turn N:   agent calls done_tool → result returned to LLM
turn N+1: LLM produces a text response with no tool calls ← unwanted narration
loop ends
```

No system-prompt instruction prevents this reliably.

## Solution

Add a first-class `halt_on_tool:` option to `Alloy.run/2`:

```elixir
# Halt after any call to the "beads" tool
Alloy.run(prompt, halt_on_tool: "beads", ...)

# Halt only after beads tool with action="transition"
Alloy.run(prompt, halt_on_tool: {"beads", "transition"}, ...)
```

The loop halts immediately after the matching tool executes, before the LLM gets another turn. Result has `status: :halted` and `error: "halt_on_tool: ..."`.

## Changes

- `Config`: `halt_on_tool` field (`String.t() | {String.t(), String.t()} | nil`, default `nil`)
- `Turn`: `after_tools/4` helper extracted from `handle_tool_use` (resolves Credo nesting depth)
- `Turn`: `halt_on_tool_match?/2` checks current-turn tool calls against the config option
- `alloy.ex` `@moduledoc`: `:halt_on_tool` documented in Options list
- `CHANGELOG.md`: `[Unreleased]` Added entry
- 4 new tests covering: name-only match, name+action match, non-matching action (no halt), nil (no halt)

## Quality gates

```
mix test              537 tests, 0 failures
mix format            ✓ no issues
mix credo --strict    ✓ no issues
mix dialyzer          ✓ Total errors: 0
```

## Note

The `:halt` mechanism already exists in `Alloy.Middleware` — this PR adds a convenience option so users don't need custom `:after_tool_execution` middleware for this common pattern. The change is surgical: one new config field, one extracted helper, one matching function.