### PR TITLE
Thread :on_event through Alloy.run/2 to match Alloy.stream/3

### DIFF
--- a/lib/alloy.ex
+++ b/lib/alloy.ex
@@ -86,7 +86,9 @@ defmodule Alloy do
   """
   @spec run(String.t() | nil, keyword()) :: {:ok, result()} | {:error, result()}
   def run(message \\ nil, opts) do
-    do_run(message, opts, [])
+    on_event = validate_on_event(Keyword.get(opts, :on_event))
+    turn_opts = maybe_put([], :on_event, on_event)
+    do_run(message, opts, turn_opts)
   end
 
   @doc """


### PR DESCRIPTION
## Summary

- `Alloy.run/2` currently calls `do_run(message, opts, [])`, silently dropping any `:on_event` callback supplied in `opts`
- `Alloy.stream/3` already extracts `:on_event` via the existing `validate_on_event/1` helper and threads it into `turn_opts` via the existing `maybe_put/3` helper (lib/alloy.ex lines 112-116)
- This PR applies the same two-line extraction to `run/2` so both entry points honor the same `:on_event` contract

## Context

A downstream project (Hive, a model-agnostic agent execution layer) needs per-tool-call observability for LLM dispatches that go through `run/2` rather than `stream/3`. The project has been carrying a local override of this same fix across \`mix deps.get\` via an idempotent reapply script. Upstreaming it here removes the need for that override.

## Diff

\`\`\`diff
   def run(message \\\\ nil, opts) do
-    do_run(message, opts, [])
+    on_event = validate_on_event(Keyword.get(opts, :on_event))
+    turn_opts = maybe_put([], :on_event, on_event)
+    do_run(message, opts, turn_opts)
   end
\`\`\`

## What this is NOT

- No new helpers; reuses the existing \`validate_on_event/1\` and \`maybe_put/3\` private functions
- No behavior change for callers that do not pass \`:on_event\`
- No new public API surface

## Test plan

- [x] \`mix compile\` clean on the patched branch against upstream main at \`11521da\`
- [ ] \`mix test\` against the Alloy test suite (local Alloy test suite not run in the drafting environment)
- [ ] Verify a downstream caller passing \`on_event: fn _event -> :ok end\` to \`Alloy.run/2\` receives \`:tool_start\` and \`:tool_end\` events

Draft PR for review. Convert to ready when the test plan is complete.