### PR TITLE
v0.10.1 — Fix 8 code review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-04-13
+
+### Fixed
+
+- **Tool result truncation** — `max_result_chars` guard now uses character count (`String.length`) instead of byte count (`byte_size`). Multi-byte UTF-8 content (CJK, emoji) was triggering truncation earlier than intended.
+- **Codex provider timeout** — `run_codex` now wraps `System.cmd` in a `Task` with a configurable timeout (default 120s). Previously a hung `codex exec` process could block the turn loop indefinitely.
+- **Symlink path traversal** — `allowed_paths` validation now resolves symlinks recursively via `resolve_real_path`, preventing symlink-based escapes from allowed directories.
+- **OpenAICompat nil guard** — added pattern match on `tc["function"]` before accessing arguments. Malformed tool call responses now return a graceful error instead of crashing the turn loop.
+- **Testing helper** — `assert_tool_called` no longer raises `ArgumentError` when matching string keys against atom-keyed input maps. Uses `safe_atom_get` with rescue fallback.
+- **Gemini streaming performance** — `parse_stream_parts` uses prepend+reverse instead of `++` accumulation, eliminating O(n²) behavior on large streaming responses.
+- **Terminate ordering** — `State.cleanup` now runs after `on_shutdown` callback and `:session_end` middleware, ensuring consumers can access state before resources are freed.
+- **Middleware docs** — documented that `{:edit, ...}`, `{:block, ...}`, and `{:halt, ...}` all stop the middleware chain immediately (first responder wins).
+
 ## [0.10.0] - 2026-04-12
 
 ### Added

--- a/lib/alloy/agent/server.ex
+++ b/lib/alloy/agent/server.ex
@@ -268,8 +268,6 @@ defmodule Alloy.Agent.Server do
       Task.Supervisor.terminate_child(Alloy.TaskSupervisor, task_pid)
     end
 
-    State.cleanup(state)
-
     state =
       case Middleware.run(:session_end, state) do
         {:halted, reason} ->
@@ -301,6 +299,9 @@ defmodule Alloy.Agent.Server do
           )
       end
     end
+
+    # Cleanup last — after all consumers (middleware, callbacks) are done.
+    State.cleanup(state)
 
     :ok
   end

--- a/lib/alloy/middleware.ex
+++ b/lib/alloy/middleware.ex
@@ -71,6 +71,10 @@ defmodule Alloy.Middleware do
 
   The `{:edit, modified_call}` return lets middleware rewrite tool arguments
   before execution. The modified call must keep the same `:id` and `:name`.
+
+  Note: `{:edit, ...}`, `{:block, ...}`, and `{:halt, ...}` all stop the
+  middleware chain immediately. The first middleware that returns one of
+  these wins — subsequent middleware modules will not see the tool call.
   """
   @spec run_before_tool_call(State.t(), map()) ::
           :ok | {:block, String.t()} | {:edit, map()} | {:halted, String.t()}

--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -138,9 +138,19 @@ defmodule Alloy.Provider.Codex do
     {command, command_args, command_opts} =
       runner_command(runner, executable, args, paths, config)
 
-    case runner.(command, command_args, command_opts) do
-      {output, status} when is_integer(status) ->
+    timeout = Map.get(config, :timeout_ms, 120_000)
+
+    task = Task.async(fn -> runner.(command, command_args, command_opts) end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {output, status}} when is_integer(status) ->
         {:ok, %{output: output, status: status}}
+
+      {:ok, other} ->
+        {:error, "codex exec returned unexpected result: #{inspect(other)}"}
+
+      nil ->
+        {:error, "codex exec timed out after #{timeout}ms"}
     end
   rescue
     error in ErlangError ->

--- a/lib/alloy/provider/gemini.ex
+++ b/lib/alloy/provider/gemini.ex
@@ -430,17 +430,20 @@ defmodule Alloy.Provider.Gemini do
   defp handle_stream_chunk(acc, _other), do: acc
 
   defp parse_stream_parts(parts) do
-    Enum.reduce(parts, {[], []}, fn part, {blocks, deltas} ->
-      block = parse_content_part(part)
+    {blocks, deltas} =
+      Enum.reduce(parts, {[], []}, fn part, {blocks, deltas} ->
+        block = parse_content_part(part)
 
-      deltas =
-        case block do
-          %{type: "text", text: text} -> deltas ++ [text]
-          _ -> deltas
-        end
+        deltas =
+          case block do
+            %{type: "text", text: text} -> [text | deltas]
+            _ -> deltas
+          end
 
-      {blocks ++ [block], deltas}
-    end)
+        {[block | blocks], deltas}
+      end)
+
+    {Enum.reverse(blocks), Enum.reverse(deltas)}
   end
 
   defp merge_usage(existing, new) do

--- a/lib/alloy/provider/openai_compat.ex
+++ b/lib/alloy/provider/openai_compat.ex
@@ -271,14 +271,18 @@ defmodule Alloy.Provider.OpenAICompat do
     tool_blocks =
       (message["tool_calls"] || [])
       |> Enum.reduce_while([], fn tc, acc ->
-        case Jason.decode(tc["function"]["arguments"]) do
-          {:ok, input} ->
-            {:cont,
-             acc ++
-               [%{type: "tool_use", id: tc["id"], name: tc["function"]["name"], input: input}]}
+        case tc["function"] do
+          %{"arguments" => args, "name" => name} ->
+            case Jason.decode(args) do
+              {:ok, input} ->
+                {:cont, acc ++ [%{type: "tool_use", id: tc["id"], name: name, input: input}]}
 
-          {:error, _} ->
-            {:halt, {:error, "Invalid JSON in tool call arguments for #{tc["function"]["name"]}"}}
+              {:error, _} ->
+                {:halt, {:error, "Invalid JSON in tool call arguments for #{name}"}}
+            end
+
+          _ ->
+            {:halt, {:error, "Malformed tool call: missing function definition"}}
         end
       end)
 

--- a/lib/alloy/testing.ex
+++ b/lib/alloy/testing.ex
@@ -180,9 +180,9 @@ defmodule Alloy.Testing do
         Enum.filter(calls, fn call ->
           call.name == name &&
             Enum.all?(expected, fn {k, v} ->
-              # Match both atom and string keys
+              # Match both atom and string keys — rescue if atom doesn't exist
               Map.get(call.input, k) == v || Map.get(call.input, to_string(k)) == v ||
-                (is_binary(k) && Map.get(call.input, String.to_existing_atom(k)) == v)
+                (is_binary(k) && safe_atom_get(call.input, k) == v)
             end)
         end)
 
@@ -203,5 +203,13 @@ defmodule Alloy.Testing do
       refute unquote(tool_name) in names,
              "Expected tool #{inspect(unquote(tool_name))} NOT to be called, but it was"
     end
+  end
+
+  @doc false
+  def safe_atom_get(map, string_key) when is_binary(string_key) do
+    String.to_existing_atom(string_key)
+    |> then(&Map.get(map, &1))
+  rescue
+    ArgumentError -> nil
   end
 end

--- a/lib/alloy/tool.ex
+++ b/lib/alloy/tool.ex
@@ -158,10 +158,36 @@ defmodule Alloy.Tool do
         {:ok, resolved}
 
       paths when is_list(paths) ->
-        if Enum.any?(paths, fn allowed -> String.starts_with?(resolved, Path.expand(allowed)) end) do
+        # Resolve symlinks to prevent escaping allowed directories via symlink traversal.
+        # Falls back to the expanded path for non-existent targets.
+        real = resolve_real_path(resolved)
+
+        if Enum.any?(paths, fn allowed ->
+             String.starts_with?(real, resolve_real_path(Path.expand(allowed)))
+           end) do
           {:ok, resolved}
         else
           {:error, "Path #{resolved} is outside allowed directories"}
+        end
+    end
+  end
+
+  defp resolve_real_path(path) do
+    case :file.read_link_all(String.to_charlist(path)) do
+      {:ok, target} ->
+        target
+        |> List.to_string()
+        |> Path.expand(Path.dirname(path))
+        |> resolve_real_path()
+
+      {:error, _} ->
+        # Not a symlink — check if a parent component is
+        parent = Path.dirname(path)
+
+        if parent == path do
+          path
+        else
+          Path.join(resolve_real_path(parent), Path.basename(path))
         end
     end
   end

--- a/lib/alloy/tool/executor.ex
+++ b/lib/alloy/tool/executor.ex
@@ -254,17 +254,23 @@ defmodule Alloy.Tool.Executor do
         :unlimited ->
           text
 
-        max when is_integer(max) and byte_size(text) > max ->
-          head = div(max * 4, 5)
-          tail = max - head
+        max when is_integer(max) ->
+          len = String.length(text)
 
-          String.slice(text, 0, head) <>
-            "\n\n[truncated " <>
-            Integer.to_string(String.length(text)) <>
-            " -> " <>
-            Integer.to_string(max) <>
-            " chars]\n\n" <>
-            String.slice(text, -tail, tail)
+          if len > max do
+            head = div(max * 4, 5)
+            tail = max - head
+
+            String.slice(text, 0, head) <>
+              "\n\n[truncated " <>
+              Integer.to_string(len) <>
+              " -> " <>
+              Integer.to_string(max) <>
+              " chars]\n\n" <>
+              String.slice(text, -tail, tail)
+          else
+            text
+          end
 
         _ ->
           text

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.10.1"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do


### PR DESCRIPTION
## Summary

Fixes 8 findings from an independent code review of the v0.10.0 codebase.

- **byte_size → String.length** in `max_result_chars` guard — UTF-8 correctness for multi-byte content
- **Codex provider timeout** — `Task.async` + `Task.yield` wrapping `System.cmd` (120s default)
- **Symlink path traversal** — `resolve_real_path` walks parent components recursively
- **OpenAICompat nil guard** — pattern match on `tc["function"]` before accessing arguments
- **Testing safe_atom_get** — rescue `ArgumentError` instead of crashing on unknown atoms
- **Gemini O(n²) fix** — prepend+reverse instead of `++` accumulation in `parse_stream_parts`
- **Terminate ordering** — `State.cleanup` moved after `on_shutdown` callback
- **Middleware docs** — documented chain-halt behavior for `:edit`/`:block`/`:halt`

## Test plan

- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] `mix test` — 568 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)