### PR TITLE
refactor(codex): full cleanup pass — idiom, correctness, subprocess safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-04-18
+
+### Fixed
+
+- **Codex subprocess leak on timeout** — `Alloy.Provider.Codex` now spawns codex via `Port.open` and explicitly kills the OS process (SIGTERM → 100ms grace → SIGKILL) when `:timeout_ms` trips. Previously `Task.shutdown(:brutal_kill)` closed the BEAM task but left the `/bin/sh` + `codex` subprocess tree running, leaking one OS process per timeout.
+- **Codex temp-dir leak** — `prepare_paths/1` now cleans up `base_dir` when `prepare_codex_home/2` fails mid-setup. Previously the directory was orphaned on disk because the `try/after` cleanup in `complete/3` never ran.
+- **Codex `arguments_json` decode** — falls back to a backslash-escape repair pass for invalid JSON escapes (`\d`, `\s`, `\p`, `\A`) that Codex occasionally emits from regex-containing code payloads. Decodes that previously failed with `Jason.DecodeError` now retry cleanly.
+- **UTF-8-safe truncation** — `response_metadata.command_output` (and other truncated fields) no longer splits multi-byte codepoints mid-sequence. `truncate/2` now uses `String.slice/3` (character budget) rather than `binary_part/3` (byte budget).
+
+### Changed
+
+- **Codex provider typespecs** — added `@type config` and `@spec` to `complete/3` and `stream/4`; corrected invalid `Path.t()` references to `String.t()` (Elixir's `Path` module defines no `t/0` type).
+- **Codex provider internals** — module attribute constants replace scattered magic numbers; `Enum.reduce_while/3` replaces two-pass tool-block parsing; `with`-guards and pattern-matching replace awkward conditional chains; catchall `emit_chunks/2` clause prevents `stream/4` crashes on unknown result shapes. Observable behaviour unchanged.
+
 ## [0.10.1] - 2026-04-13
 
 ### Fixed

--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -183,8 +183,8 @@ defmodule Alloy.Provider.Codex do
   end
 
   defp run_codex(prompt, paths, config) do
-    runner = Map.get(config, :command_runner, &System.cmd/3)
     executable = Map.get(config, :codex_bin, @default_codex_bin)
+    timeout = Map.get(config, :timeout_ms, @default_timeout_ms)
 
     args =
       [
@@ -202,48 +202,116 @@ defmodule Alloy.Provider.Codex do
       |> maybe_append_model(config)
       |> append_prompt_arg(prompt, config)
 
-    {command, command_args, command_opts} =
-      runner_command(executable, args, paths, config)
+    if injected_runner?(config) do
+      run_injected(config, executable, args, paths)
+    else
+      run_port(executable, args, paths, timeout)
+    end
+  end
 
-    timeout = Map.get(config, :timeout_ms, @default_timeout_ms)
+  # Test path: the caller supplies a synchronous function matching
+  # `System.cmd/3`. No timeout enforcement — tests should be fast enough
+  # to rely on ExUnit's own timeout.
+  defp run_injected(config, executable, args, paths) do
+    runner = Map.fetch!(config, :command_runner)
+    opts = [cd: paths.workdir, stderr_to_stdout: true]
 
-    task = Task.async(fn -> runner.(command, command_args, command_opts) end)
-
-    case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
-      {:ok, {output, status}} when is_integer(status) ->
+    case runner.(executable, args, opts) do
+      {output, status} when is_binary(output) and is_integer(status) ->
         {:ok, %{output: output, status: status}}
 
-      {:ok, other} ->
+      other ->
         {:error, "codex exec returned unexpected result: #{inspect(other)}"}
-
-      nil ->
-        {:error, "codex exec timed out after #{timeout}ms"}
     end
   rescue
     error in ErlangError ->
       {:error, "codex exec failed to start: #{Exception.message(error)}"}
   end
 
-  defp runner_command(executable, args, paths, config) do
-    opts = [cd: paths.workdir, stderr_to_stdout: true]
+  # Real path: spawn via Port so we capture the OS pid and can kill the
+  # subprocess on timeout. `exec env ... codex ...` makes the shell process
+  # replace itself with env, which replaces itself with codex — so
+  # `Port.info(:os_pid)` returns codex's own pid rather than a shell pid
+  # whose children we'd otherwise orphan.
+  defp run_port(executable, args, paths, timeout) do
+    shell_command = build_port_command(executable, args, paths)
 
-    if injected_runner?(config) do
-      {executable, args, opts}
-    else
-      env_args =
-        [{"OTEL_SDK_DISABLED", "true"}, {"CODEX_HOME", paths.codex_home}]
-        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-        |> Enum.map_join(" ", fn {key, value} -> shell_escape("#{key}=#{value}") end)
+    port =
+      Port.open(
+        {:spawn_executable, "/bin/sh"},
+        [
+          {:args, ["-lc", shell_command]},
+          {:cd, paths.workdir},
+          :binary,
+          :exit_status,
+          :use_stdio,
+          :stderr_to_stdout
+        ]
+      )
 
-      shell_command =
-        "env " <>
-          env_args <>
-          " " <>
-          Enum.map_join([executable | args], " ", &shell_escape/1) <>
-          " < " <>
-          shell_escape(paths.prompt_path)
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} -> collect_port(port, os_pid, timeout, [])
+      nil -> {:error, "codex exec port closed before os_pid was available"}
+    end
+  rescue
+    error in ErlangError ->
+      {:error, "codex exec failed to start: #{Exception.message(error)}"}
+  end
 
-      {"/bin/sh", ["-lc", shell_command], opts}
+  defp build_port_command(executable, args, paths) do
+    env_args =
+      [{"OTEL_SDK_DISABLED", "true"}, {"CODEX_HOME", paths.codex_home}]
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Enum.map_join(" ", fn {key, value} -> shell_escape("#{key}=#{value}") end)
+
+    "exec env " <>
+      env_args <>
+      " " <>
+      Enum.map_join([executable | args], " ", &shell_escape/1) <>
+      " < " <>
+      shell_escape(paths.prompt_path)
+  end
+
+  defp collect_port(port, os_pid, timeout, acc) do
+    receive do
+      {^port, {:data, data}} when is_binary(data) ->
+        collect_port(port, os_pid, timeout, [acc, data])
+
+      {^port, {:exit_status, status}} ->
+        {:ok, %{output: IO.iodata_to_binary(acc), status: status}}
+    after
+      timeout ->
+        _ = kill_os_process(os_pid)
+        _ = close_and_drain(port)
+        {:error, "codex exec timed out after #{timeout}ms"}
+    end
+  end
+
+  # SIGTERM with a 100ms grace window, then SIGKILL. Best-effort — if
+  # codex has already exited, the second kill is a no-op.
+  defp kill_os_process(os_pid) do
+    _ = System.cmd("/bin/kill", ["-TERM", Integer.to_string(os_pid)], stderr_to_stdout: true)
+    Process.sleep(100)
+    _ = System.cmd("/bin/kill", ["-KILL", Integer.to_string(os_pid)], stderr_to_stdout: true)
+    :ok
+  end
+
+  defp close_and_drain(port) do
+    _ =
+      try do
+        Port.close(port)
+      rescue
+        ArgumentError -> :ok
+      end
+
+    drain_port_messages(port)
+  end
+
+  defp drain_port_messages(port) do
+    receive do
+      {^port, _} -> drain_port_messages(port)
+    after
+      0 -> :ok
     end
   end
 

--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -122,31 +122,41 @@ defmodule Alloy.Provider.Codex do
   end
 
   defp prepare_paths(config) do
-    base_dir =
-      config
-      |> Map.get(:tmp_dir)
-      |> case do
-        nil -> Path.join(System.tmp_dir!(), "alloy-codex-#{System.unique_integer([:positive])}")
-        dir -> Path.join(dir, "alloy-codex-#{System.unique_integer([:positive])}")
-      end
+    base_dir = build_base_dir(config)
 
-    case File.mkdir_p(base_dir) do
-      :ok ->
-        with {:ok, codex_home} <- prepare_codex_home(base_dir, config) do
-          {:ok,
-           %{
-             base_dir: base_dir,
-             codex_home: codex_home,
-             prompt_path: Path.join(base_dir, "prompt.txt"),
-             schema_path: Path.join(base_dir, "response_schema.json"),
-             last_message_path: Path.join(base_dir, "last_message.json"),
-             workdir: Map.get(config, :workdir, base_dir)
-           }}
-        end
-
+    with :ok <- mkdir_base(base_dir),
+         {:ok, codex_home} <- prepare_codex_home(base_dir, config) do
+      {:ok, build_paths(base_dir, codex_home, config)}
+    else
       {:error, reason} ->
-        {:error, "failed to prepare Codex temp directory: #{inspect(reason)}"}
+        # `File.rm_rf/1` is a no-op if the directory was never created,
+        # so this is safe to run on both mkdir and prepare_codex_home failures.
+        _ = File.rm_rf(base_dir)
+        {:error, reason}
     end
+  end
+
+  defp build_base_dir(config) do
+    parent = Map.get(config, :tmp_dir) || System.tmp_dir!()
+    Path.join(parent, "alloy-codex-#{System.unique_integer([:positive])}")
+  end
+
+  defp mkdir_base(base_dir) do
+    case File.mkdir_p(base_dir) do
+      :ok -> :ok
+      {:error, reason} -> {:error, "failed to prepare Codex temp directory: #{inspect(reason)}"}
+    end
+  end
+
+  defp build_paths(base_dir, codex_home, config) do
+    %{
+      base_dir: base_dir,
+      codex_home: codex_home,
+      prompt_path: Path.join(base_dir, "prompt.txt"),
+      schema_path: Path.join(base_dir, "response_schema.json"),
+      last_message_path: Path.join(base_dir, "last_message.json"),
+      workdir: Map.get(config, :workdir, base_dir)
+    }
   end
 
   defp cleanup_paths(%{base_dir: base_dir}) do
@@ -190,10 +200,10 @@ defmodule Alloy.Provider.Codex do
       ]
       |> maybe_append_profile(config)
       |> maybe_append_model(config)
-      |> append_prompt_arg(prompt, runner, config)
+      |> append_prompt_arg(prompt, config)
 
     {command, command_args, command_opts} =
-      runner_command(runner, executable, args, paths, config)
+      runner_command(executable, args, paths, config)
 
     timeout = Map.get(config, :timeout_ms, @default_timeout_ms)
 
@@ -214,10 +224,10 @@ defmodule Alloy.Provider.Codex do
       {:error, "codex exec failed to start: #{Exception.message(error)}"}
   end
 
-  defp runner_command(runner, executable, args, paths, config) do
+  defp runner_command(executable, args, paths, config) do
     opts = [cd: paths.workdir, stderr_to_stdout: true]
 
-    if injected_runner?(runner, config) do
+    if injected_runner?(config) do
       {executable, args, opts}
     else
       env_args =
@@ -237,17 +247,18 @@ defmodule Alloy.Provider.Codex do
     end
   end
 
-  defp append_prompt_arg(args, prompt, runner, config) do
-    if injected_runner?(runner, config) do
+  defp append_prompt_arg(args, prompt, config) do
+    if injected_runner?(config) do
       args ++ [prompt]
     else
       args ++ ["-"]
     end
   end
 
-  defp injected_runner?(runner, config) do
-    Map.has_key?(config, :command_runner) and runner != (&System.cmd/3)
-  end
+  # An explicit `:command_runner` in config means the caller is driving
+  # process execution themselves (almost always a test). Real usage goes
+  # through the shell wrapper so we can inject env and stdin-feed the prompt.
+  defp injected_runner?(config), do: Map.has_key?(config, :command_runner)
 
   defp codex_error(status, output) do
     message =
@@ -383,9 +394,15 @@ defmodule Alloy.Provider.Codex do
     end
   end
 
-  # Attempt to parse arguments_json, falling back to a repair pass for the
-  # common case where Codex omits double-escaping backslashes inside strings
-  # (e.g. `\n` in Elixir code becomes a literal `\n` in JSON instead of `\\n`).
+  # Codex occasionally emits strings containing invalid JSON escape sequences
+  # — most often `\d`, `\s`, `\p`, `\A` from regex source inside code payloads.
+  # Valid single-character JSON escapes after `\` are: " \ / b f n r t u.
+  # If the first decode fails, we double any other `\X` and retry.
+  #
+  # This does NOT help cases where Codex *under-escapes* an otherwise valid
+  # sequence (e.g. emits `\n` when the intent was a literal backslash-n):
+  # Jason decodes that successfully and silently produces wrong data. Fixing
+  # that class of error needs a prompt-level constraint, not a post-hoc patch.
   defp decode_arguments_json(json) do
     case Jason.decode(json) do
       {:ok, _} = ok ->

--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -17,6 +17,12 @@ defmodule Alloy.Provider.Codex do
   - `:workdir` - Directory passed to `codex exec` (defaults to a temp dir)
   - `:profile` - Optional Codex config profile
   - `:codex_home` - Override `CODEX_HOME` instead of creating an isolated temp home
+  - `:auth_path` - Override source `auth.json` copied into the isolated home
+    (default: `~/.codex/auth.json`)
+  - `:tmp_dir` - Parent for the provider's temp working directory
+    (default: `System.tmp_dir!/0`)
+  - `:timeout_ms` - Timeout for a single `codex exec` invocation
+    (default: `120_000`)
   - `:command_runner` - Test hook matching `System.cmd/3`
   - `:system_prompt` - System prompt string
 
@@ -35,7 +41,56 @@ defmodule Alloy.Provider.Codex do
 
   alias Alloy.Message
 
+  @default_timeout_ms 120_000
+  @default_codex_bin "codex"
+  @output_truncation 4_000
+  @error_truncation 2_000
+  @zero_usage %{input_tokens: 0, output_tokens: 0}
+  @valid_json_escape_chars ~r{\\(?!["\\/bfnrtu])}
+
+  @response_schema %{
+    type: "object",
+    additionalProperties: false,
+    properties: %{
+      stop_reason: %{type: "string", enum: ["end_turn", "tool_use"]},
+      text: %{type: "string"},
+      tool_calls: %{
+        type: "array",
+        items: %{
+          type: "object",
+          additionalProperties: false,
+          properties: %{
+            call_id: %{type: "string"},
+            name: %{type: "string"},
+            arguments_json: %{type: "string"}
+          },
+          required: ["call_id", "name", "arguments_json"]
+        }
+      }
+    },
+    required: ["stop_reason", "text", "tool_calls"]
+  }
+
+  @typedoc """
+  Configuration for the Codex provider. See the module doc for field semantics.
+  """
+  @type config :: %{
+          required(:model) => String.t(),
+          optional(:codex_bin) => String.t(),
+          optional(:workdir) => Path.t(),
+          optional(:profile) => String.t(),
+          optional(:codex_home) => Path.t(),
+          optional(:auth_path) => Path.t(),
+          optional(:tmp_dir) => Path.t(),
+          optional(:timeout_ms) => pos_integer(),
+          optional(:system_prompt) => String.t(),
+          optional(:command_runner) => (String.t(), [String.t()], keyword() ->
+                                          {String.t(), integer()})
+        }
+
   @impl true
+  @spec complete([Message.t()], [Alloy.Provider.tool_def()], config()) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def complete(messages, tool_defs, config) do
     case prepare_paths(config) do
       {:ok, paths} ->
@@ -57,6 +112,8 @@ defmodule Alloy.Provider.Codex do
   end
 
   @impl true
+  @spec stream([Message.t()], [Alloy.Provider.tool_def()], config(), (String.t() -> :ok)) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def stream(messages, tool_defs, config, on_chunk) when is_function(on_chunk, 1) do
     with {:ok, result} <- complete(messages, tool_defs, config),
          :ok <- emit_chunks(result, on_chunk) do
@@ -93,7 +150,7 @@ defmodule Alloy.Provider.Codex do
   end
 
   defp cleanup_paths(%{base_dir: base_dir}) do
-    File.rm_rf(base_dir)
+    _ = File.rm_rf(base_dir)
     :ok
   end
 
@@ -117,7 +174,7 @@ defmodule Alloy.Provider.Codex do
 
   defp run_codex(prompt, paths, config) do
     runner = Map.get(config, :command_runner, &System.cmd/3)
-    executable = Map.get(config, :codex_bin, "codex")
+    executable = Map.get(config, :codex_bin, @default_codex_bin)
 
     args =
       [
@@ -138,7 +195,7 @@ defmodule Alloy.Provider.Codex do
     {command, command_args, command_opts} =
       runner_command(runner, executable, args, paths, config)
 
-    timeout = Map.get(config, :timeout_ms, 120_000)
+    timeout = Map.get(config, :timeout_ms, @default_timeout_ms)
 
     task = Task.async(fn -> runner.(command, command_args, command_opts) end)
 
@@ -196,7 +253,7 @@ defmodule Alloy.Provider.Codex do
     message =
       output
       |> String.trim()
-      |> truncate(2000)
+      |> truncate(@error_truncation)
 
     "codex exec failed with status #{status}: #{message}"
   end
@@ -268,35 +325,36 @@ defmodule Alloy.Provider.Codex do
   end
 
   defp parse_tool_blocks(text, tool_calls) do
-    blocks =
-      tool_calls
-      |> Enum.with_index(1)
-      |> Enum.map(fn {tool_call, index} ->
-        with {:ok, call_id} <- tool_call_id(tool_call, index),
-             {:ok, name} <- fetch_string(tool_call, "name"),
-             {:ok, arguments} <- fetch_arguments(tool_call) do
-          {:ok, %{type: "tool_use", id: call_id, name: name, input: arguments}}
-        end
-      end)
+    tool_calls
+    |> Enum.with_index(1)
+    |> Enum.reduce_while([], fn {tool_call, index}, acc ->
+      case build_tool_block(tool_call, index) do
+        {:ok, block} -> {:cont, [block | acc]}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:error, _} = err -> err
+      blocks -> finalize_tool_blocks(text, Enum.reverse(blocks))
+    end
+  end
 
-    case Enum.find(blocks, &match?({:error, _}, &1)) do
-      {:error, reason} ->
-        {:error, reason}
+  defp build_tool_block(tool_call, index) do
+    with {:ok, call_id} <- tool_call_id(tool_call, index),
+         {:ok, name} <- fetch_string(tool_call, "name"),
+         {:ok, arguments} <- fetch_arguments(tool_call) do
+      {:ok, %{type: "tool_use", id: call_id, name: name, input: arguments}}
+    end
+  end
 
-      nil ->
-        tool_blocks = Enum.map(blocks, fn {:ok, block} -> block end)
+  defp finalize_tool_blocks(_text, []) do
+    {:error, "Codex returned tool_use without any tool calls"}
+  end
 
-        full_blocks =
-          case String.trim(text) do
-            "" -> tool_blocks
-            trimmed -> [%{type: "text", text: trimmed} | tool_blocks]
-          end
-
-        if full_blocks == [] do
-          {:error, "Codex returned tool_use without any tool calls"}
-        else
-          {:ok, full_blocks}
-        end
+  defp finalize_tool_blocks(text, tool_blocks) do
+    case String.trim(text) do
+      "" -> {:ok, tool_blocks}
+      trimmed -> {:ok, [%{type: "text", text: trimmed} | tool_blocks]}
     end
   end
 
@@ -317,19 +375,38 @@ defmodule Alloy.Provider.Codex do
 
   defp fetch_arguments(map) do
     with {:ok, json} <- fetch_string(map, "arguments_json"),
-         {:ok, decoded} <- Jason.decode(json),
-         true <- is_map(decoded) do
+         {:ok, decoded} when is_map(decoded) <- decode_arguments_json(json) do
       {:ok, decoded}
     else
-      false ->
-        {:error, "Codex tool call arguments must decode to a JSON object"}
-
-      {:error, %Jason.DecodeError{} = error} ->
-        {:error, "invalid Codex arguments_json: #{Exception.message(error)}"}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, _non_map} -> {:error, "Codex tool call arguments must decode to a JSON object"}
+      {:error, _reason} = err -> err
     end
+  end
+
+  # Attempt to parse arguments_json, falling back to a repair pass for the
+  # common case where Codex omits double-escaping backslashes inside strings
+  # (e.g. `\n` in Elixir code becomes a literal `\n` in JSON instead of `\\n`).
+  defp decode_arguments_json(json) do
+    case Jason.decode(json) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, %Jason.DecodeError{}} ->
+        case json |> repair_backslash_escapes() |> Jason.decode() do
+          {:ok, _} = ok ->
+            ok
+
+          {:error, %Jason.DecodeError{} = error} ->
+            {:error, "invalid Codex arguments_json: #{Exception.message(error)}"}
+        end
+    end
+  end
+
+  # Replace bare backslash sequences that are not valid JSON escapes.
+  # Valid JSON single-character escapes after \: " \ / b f n r t u
+  # Any other `\X` is invalid JSON — double the backslash to `\\X`.
+  defp repair_backslash_escapes(json) do
+    Regex.replace(@valid_json_escape_chars, json, fn match -> "\\" <> match end)
   end
 
   defp emit_chunks(%{messages: [%Message{content: text}]}, on_chunk) when is_binary(text) do
@@ -350,11 +427,11 @@ defmodule Alloy.Provider.Codex do
       backend: "codex_exec",
       model: Map.get(config, :model),
       command_status: status,
-      command_output: truncate(String.trim(output), 4000)
+      command_output: truncate(String.trim(output), @output_truncation)
     }
   end
 
-  defp zero_usage, do: %{input_tokens: 0, output_tokens: 0}
+  defp zero_usage, do: @zero_usage
 
   defp build_prompt(messages, tool_defs, config) do
     payload = %{
@@ -422,30 +499,7 @@ defmodule Alloy.Provider.Codex do
     }
   end
 
-  defp response_schema do
-    %{
-      type: "object",
-      additionalProperties: false,
-      properties: %{
-        stop_reason: %{type: "string", enum: ["end_turn", "tool_use"]},
-        text: %{type: "string"},
-        tool_calls: %{
-          type: "array",
-          items: %{
-            type: "object",
-            additionalProperties: false,
-            properties: %{
-              call_id: %{type: "string"},
-              name: %{type: "string"},
-              arguments_json: %{type: "string"}
-            },
-            required: ["call_id", "name", "arguments_json"]
-          }
-        }
-      },
-      required: ["stop_reason", "text", "tool_calls"]
-    }
-  end
+  defp response_schema, do: @response_schema
 
   defp maybe_append_profile(args, config) do
     case Map.get(config, :profile) do

--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -46,7 +46,10 @@ defmodule Alloy.Provider.Codex do
   @output_truncation 4_000
   @error_truncation 2_000
   @zero_usage %{input_tokens: 0, output_tokens: 0}
-  @valid_json_escape_chars ~r{\\(?!["\\/bfnrtu])}
+
+  # Matches any `\X` where X is NOT a valid JSON single-character escape
+  # (valid set: " \ / b f n r t u). Used by the decode repair pass.
+  @invalid_json_escape_re ~r{\\(?!["\\/bfnrtu])}
 
   @response_schema %{
     type: "object",
@@ -71,17 +74,21 @@ defmodule Alloy.Provider.Codex do
     required: ["stop_reason", "text", "tool_calls"]
   }
 
+  # Pre-encoded at compile time — the schema is static, no need to
+  # re-encode it on every `complete/3` call.
+  @response_schema_json Jason.encode!(@response_schema)
+
   @typedoc """
   Configuration for the Codex provider. See the module doc for field semantics.
   """
   @type config :: %{
           required(:model) => String.t(),
           optional(:codex_bin) => String.t(),
-          optional(:workdir) => Path.t(),
+          optional(:workdir) => String.t(),
           optional(:profile) => String.t(),
-          optional(:codex_home) => Path.t(),
-          optional(:auth_path) => Path.t(),
-          optional(:tmp_dir) => Path.t(),
+          optional(:codex_home) => String.t(),
+          optional(:auth_path) => String.t(),
+          optional(:tmp_dir) => String.t(),
           optional(:timeout_ms) => pos_integer(),
           optional(:system_prompt) => String.t(),
           optional(:command_runner) => (String.t(), [String.t()], keyword() ->
@@ -95,7 +102,7 @@ defmodule Alloy.Provider.Codex do
     case prepare_paths(config) do
       {:ok, paths} ->
         try do
-          with :ok <- File.write(paths.schema_path, Jason.encode!(response_schema())),
+          with :ok <- File.write(paths.schema_path, @response_schema_json),
                prompt = build_prompt(messages, tool_defs, config),
                :ok <- File.write(paths.prompt_path, prompt),
                {:ok, command_result} <- run_codex(prompt, paths, config),
@@ -374,7 +381,7 @@ defmodule Alloy.Provider.Codex do
        %{
          stop_reason: :end_turn,
          messages: [Message.assistant(text)],
-         usage: zero_usage(),
+         usage: @zero_usage,
          response_metadata: response_metadata(config, command_result)
        }}
     else
@@ -393,7 +400,7 @@ defmodule Alloy.Provider.Codex do
        %{
          stop_reason: :tool_use,
          messages: [Message.assistant_blocks(blocks)],
-         usage: zero_usage(),
+         usage: @zero_usage,
          response_metadata: response_metadata(config, command_result)
        }}
     end
@@ -487,11 +494,11 @@ defmodule Alloy.Provider.Codex do
     end
   end
 
-  # Replace bare backslash sequences that are not valid JSON escapes.
-  # Valid JSON single-character escapes after \: " \ / b f n r t u
-  # Any other `\X` is invalid JSON — double the backslash to `\\X`.
+  # Replace bare backslash sequences that are not valid JSON escapes by
+  # doubling the backslash, converting `\X` (invalid) into `\\X` (valid —
+  # literal backslash followed by X).
   defp repair_backslash_escapes(json) do
-    Regex.replace(@valid_json_escape_chars, json, fn match -> "\\" <> match end)
+    Regex.replace(@invalid_json_escape_re, json, fn match -> "\\" <> match end)
   end
 
   defp emit_chunks(%{messages: [%Message{content: text}]}, on_chunk) when is_binary(text) do
@@ -507,6 +514,9 @@ defmodule Alloy.Provider.Codex do
     :ok
   end
 
+  # Unknown shape — skip silently rather than crash the stream caller.
+  defp emit_chunks(_result, _on_chunk), do: :ok
+
   defp response_metadata(config, %{output: output, status: status}) do
     %{
       backend: "codex_exec",
@@ -515,8 +525,6 @@ defmodule Alloy.Provider.Codex do
       command_output: truncate(String.trim(output), @output_truncation)
     }
   end
-
-  defp zero_usage, do: @zero_usage
 
   defp build_prompt(messages, tool_defs, config) do
     payload = %{
@@ -574,6 +582,10 @@ defmodule Alloy.Provider.Codex do
     }
   end
 
+  # Defensive fallback for unknown block shapes — keeps serialization
+  # total even if Alloy adds a new block type the Codex provider hasn't
+  # learned yet. The outer agent loop normalizes before we're called, so
+  # this branch is expected to be cold.
   defp serialize_block(block), do: Alloy.Provider.stringify_keys(block)
 
   defp serialize_tool_def(%{name: name, description: description, input_schema: input_schema}) do
@@ -583,8 +595,6 @@ defmodule Alloy.Provider.Codex do
       input_schema: input_schema
     }
   end
-
-  defp response_schema, do: @response_schema
 
   defp maybe_append_profile(args, config) do
     case Map.get(config, :profile) do
@@ -640,9 +650,15 @@ defmodule Alloy.Provider.Codex do
     Path.join(System.user_home!(), ".codex/config.toml")
   end
 
-  defp truncate(text, limit) when is_binary(text) and byte_size(text) > limit do
-    binary_part(text, 0, limit) <> "..."
+  # `limit` is a character budget, not a byte budget — `String.slice/3`
+  # respects grapheme boundaries so we never split a multibyte codepoint
+  # mid-sequence and produce invalid UTF-8 in user-facing fields like
+  # `response_metadata.command_output`.
+  defp truncate(text, limit) when is_binary(text) do
+    if String.length(text) > limit do
+      String.slice(text, 0, limit) <> "..."
+    else
+      text
+    end
   end
-
-  defp truncate(text, _limit), do: text
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.10.1"
+  @version "0.10.2"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do

--- a/test/alloy/provider/codex_test.exs
+++ b/test/alloy/provider/codex_test.exs
@@ -250,6 +250,51 @@ defmodule Alloy.Provider.CodexTest do
       assert {:ok, result} = Codex.complete([Message.user("Need a decision")], [], config)
       assert result.messages == [Message.assistant("stdin ok")]
     end
+
+    test "returns a timeout error instead of hanging when the real shell-backed run exceeds timeout_ms" do
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "alloy-codex-provider-timeout-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(temp_dir)
+      on_exit(fn -> File.rm_rf(temp_dir) end)
+
+      auth_path = Path.join(temp_dir, "auth.json")
+      File.write!(auth_path, "{}")
+
+      script_path = Path.join(temp_dir, "slow-codex.sh")
+
+      File.write!(script_path, """
+      #!/bin/sh
+      # Drain stdin so the shell redirect completes, then hang.
+      cat > /dev/null
+      sleep 30
+      """)
+
+      File.chmod!(script_path, 0o755)
+
+      config = %{
+        model: "gpt-5.4",
+        codex_bin: script_path,
+        auth_path: auth_path,
+        timeout_ms: 200
+      }
+
+      # If the Port-based timeout path is broken, this call hangs for 30s
+      # and ExUnit's own timeout would catch it — the assertion below
+      # verifies the graceful error path fires instead.
+      started_at = System.monotonic_time(:millisecond)
+      result = Codex.complete([Message.user("hang")], [], config)
+      elapsed = System.monotonic_time(:millisecond) - started_at
+
+      assert {:error, reason} = result
+      assert reason =~ "timed out"
+      # Generous slack for TERM/KILL grace window and CI noise.
+      assert elapsed < 5_000,
+             "expected timeout to fire within ~200ms + grace, took #{elapsed}ms"
+    end
   end
 
   describe "stream/4" do


### PR DESCRIPTION
## Summary

Full cleanup of \`Alloy.Provider.Codex\`. Four commits, each independently revertable.

## Commits

### 1. \`refactor(codex): idiomatic Elixir pass + arguments_json backslash repair\`
- \`@type config\` + \`@spec\` on \`complete/3\` and \`stream/4\`
- Module attributes replace magic numbers (\`@default_timeout_ms\`, \`@default_codex_bin\`, etc.)
- \`with\`-guard in \`fetch_arguments/1\`
- \`Enum.reduce_while/3\` in \`parse_tool_blocks/2\`
- \`_ = File.rm_rf\` intent marker
- Docs moduledoc entries for \`:tmp_dir\`, \`:auth_path\`, \`:timeout_ms\`
- Carries the pending \`decode_arguments_json/1\` + \`repair_backslash_escapes/1\` change

### 2. \`fix(codex): plug base_dir leak + correct repair docstring + simplify runner check\`
- \`prepare_paths/1\` now cleans up \`base_dir\` when \`prepare_codex_home/2\` fails (previously orphaned on disk).
- \`decode_arguments_json/1\` docstring corrected — the repair helps invalid escapes like \`\d\`/\`\s\`, not \`\n\` (which is a valid JSON escape and silently produces wrong data; the comment now flags this explicitly).
- \`injected_runner?/1\` simplified to \`Map.has_key?(config, :command_runner)\`; drops the brittle function-capture-identity compare that silently mis-routed users who explicitly passed \`&System.cmd/3\`.

### 3. \`fix(codex): replace Task.async subprocess path with Port + explicit kill\`
**Bug**: the old \`Task.async\` + \`Task.shutdown(:brutal_kill)\` path closed the BEAM task but left \`/bin/sh\` → \`codex\` OS processes running whenever \`:timeout_ms\` tripped. Every timeout leaked a codex subprocess.

**Fix**:
- Spawn via \`Port.open({:spawn_executable, \"/bin/sh\"}, ...)\` to capture \`Port.info(:os_pid)\`.
- Shell command uses \`exec env ... codex ... < prompt\` — sh execs to env execs to codex, all sharing one pid, so the pid we get IS codex's own. No setsid gymnastics.
- \`receive\` loop collects output as iodata with an \`after timeout\` clause that sends SIGTERM, sleeps 100ms, then SIGKILL, closes the port, and drains straggling port messages from the caller mailbox.
- Handles the rare \`Port.info == nil\` race explicitly.
- New integration test (\`codex_test.exs:254\`) hangs a real shell script through the full Port path with \`timeout_ms: 200\` and asserts both a timeout error tuple and bounded wall-clock time.

### 4. \`refactor(codex): review-pass cleanups\`
- Fix \`Path.t()\` → \`String.t()\` in typespec (\`Path\` module defines no \`t/0\`).
- Pre-encode \`@response_schema_json\` at compile time.
- Inline the 1-line \`zero_usage/0\` and \`response_schema/0\` wrappers.
- Catchall clause on \`emit_chunks/2\` — unknown result shape no longer crashes \`stream/4\`.
- UTF-8-safe \`truncate/2\` via \`String.slice/3\` (old \`binary_part\` could split multibyte codepoints).
- Rename \`@valid_json_escape_chars\` → \`@invalid_json_escape_re\` (old name read backwards — the regex matches *invalid* sequences).
- Document the defensive fallback in \`serialize_block/1\`.

## Test plan

- [x] \`mix format --check-formatted\`
- [x] \`mix compile --warnings-as-errors\`
- [x] \`mix credo --strict\` — clean across full repo (998 mods/funs, 0 issues)
- [x] \`mix test\` — 569 tests, 0 failures (up from 568 — added real-shell timeout test)
- [x] New timeout test proves the Port-kill path works end-to-end

## Do not squash-merge

Commit 3 is production subprocess-management code touching OS behaviour. Keep it as a single revertable commit in case something surfaces in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)