### PR TITLE
feat(xai): add grok-4.20 family to the model catalog

### DIFF
--- a/lib/alloy/model_metadata.ex
+++ b/lib/alloy/model_metadata.ex
@@ -56,6 +56,14 @@ defmodule Alloy.ModelMetadata do
     %{name: "grok-4", limit: 2_000_000, suffix_patterns: [""]},
     %{name: "grok-4-fast-reasoning", limit: 2_000_000, suffix_patterns: [""]},
     %{name: "grok-4-fast-non-reasoning", limit: 2_000_000, suffix_patterns: [""]},
+    # grok-4.20 family — current xAI frontier API models. The `-0309`
+    # suffix is a date stamp; regex patterns accept any 4-digit stamp so
+    # future snapshots on the same family won't need a code change.
+    %{
+      name: "grok-4.20",
+      limit: 2_000_000,
+      suffix_patterns: [~r/^-\d{4}-(reasoning|non-reasoning)$/, ~r/^-multi-agent-\d{4}$/]
+    },
     # Dash notation (grok-4-1-fast-*) for backward compat
     %{name: "grok-4-1-fast-reasoning", limit: 2_000_000, suffix_patterns: [""]},
     %{name: "grok-4-1-fast-non-reasoning", limit: 2_000_000, suffix_patterns: [""]},

--- a/lib/alloy/provider/xai.ex
+++ b/lib/alloy/provider/xai.ex
@@ -9,7 +9,8 @@ defmodule Alloy.Provider.XAI do
 
   Required:
   - `:api_key` - xAI API key
-  - `:model` - Model name (e.g., "grok-4", "grok-4.1-fast-reasoning", "grok-code-fast-1")
+  - `:model` - Model name (e.g., `"grok-4.20-0309-reasoning"`,
+    `"grok-4.1-fast-reasoning"`, `"grok-code-fast-1"`)
 
   Optional:
   - `:web_search` - `true` or config map to enable Grok's web search tool
@@ -21,7 +22,7 @@ defmodule Alloy.Provider.XAI do
       Alloy.run("What's happening on X today?",
         provider: {Alloy.Provider.XAI,
           api_key: System.get_env("XAI_API_KEY"),
-          model: "grok-4",
+          model: "grok-4.20-0309-reasoning",
           web_search: true
         }
       )

--- a/test/alloy/model_metadata_test.exs
+++ b/test/alloy/model_metadata_test.exs
@@ -13,6 +13,10 @@ defmodule Alloy.ModelMetadataTest do
       # grok-4.1-fast models (dot notation)
       assert ModelMetadata.context_window("grok-4.1-fast") == 2_000_000
       assert ModelMetadata.context_window("grok-4.1-fast-reasoning") == 2_000_000
+      # grok-4.20 family — current xAI frontier API models
+      assert ModelMetadata.context_window("grok-4.20-0309-reasoning") == 2_000_000
+      assert ModelMetadata.context_window("grok-4.20-0309-non-reasoning") == 2_000_000
+      assert ModelMetadata.context_window("grok-4.20-multi-agent-0309") == 2_000_000
     end
 
     test "returns dated snapshot matches" do


### PR DESCRIPTION
## Summary

Adds \`grok-4.20-0309-reasoning\`, \`grok-4.20-0309-non-reasoning\`, and \`grok-4.20-multi-agent-0309\` to \`Alloy.ModelMetadata\`. These are xAI's current frontier API models ([docs.x.ai/developers/models](https://docs.x.ai/developers/models)) but were missing from the catalog.

### Why this matters

The \`XAI\` provider is a thin wrapper, so users could technically already pass \`model: \"grok-4.20-0309-reasoning\"\` as a string and it would route correctly. But without a \`ModelMetadata\` entry, the Compactor fell back to \`@default_limit 200_000\` instead of the real 2M-token window — leading to premature compaction and wasted turns.

### Changes

- \`lib/alloy/model_metadata.ex\` — one entry with regex suffix patterns covering the reasoning, non-reasoning, and multi-agent snapshots. Regex (not literal strings) so future date stamps on the same family don't need a catalog update.
- \`lib/alloy/provider/xai.ex\` — docstring example now uses \`grok-4.20-0309-reasoning\` as the default-suggestion model (was \`grok-4\`).
- \`test/alloy/model_metadata_test.exs\` — three new assertions locking in the 2M context window for all three variants.

## What's NOT in this PR

**Grok 4.3 beta** is visible on [grok.com Early Access](https://phemex.com/news/article/xai-launches-grok-43-beta-with-enhanced-features-73950) but not yet exposed via the xAI API — adding a model ID without API support would be guessing at both the name and context window. Will ship a follow-up when it lands in the API docs.

## Test plan

- [x] \`mix format --check-formatted\`
- [x] \`mix compile --warnings-as-errors\`
- [x] \`mix credo --strict\` — clean
- [x] \`mix test test/alloy/model_metadata_test.exs\` — 8/8 passing

## Release

Patch bump candidate (\`0.10.3\`) if you want it in the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)