### PR TITLE
feat: 0.11.0 — provider typespec parity + grok-4.20 catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-04-21
+
+### Added
+
+- **grok-4.20 family in the model catalog** — `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, and `grok-4.20-multi-agent-0309` now register their real 2M-token context window in `Alloy.ModelMetadata`. Users who explicitly pass one of these model IDs to `Alloy.Provider.XAI` no longer hit the generic 200K fallback in the Compactor. Suffix patterns use regex so future `-MMDD` snapshots on the same family don't need a catalog update.
+- **Provider typespec parity** — every provider that implements the `Alloy.Provider` behaviour now exposes a `@type config` and `@spec` on `complete/3` and `stream/4`. Users who run dialyzer get type-checking at call sites for all six providers (previously only `Codex`). No runtime change — this is purely a tooling-visibility improvement.
+
+### Changed
+
+- **`Alloy.Provider.XAI` docstring example** — now uses `grok-4.20-0309-reasoning` as the default-suggestion model (was `grok-4`) to reflect the current xAI API frontier.
+
 ## [0.10.2] - 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alloy is the completion-tool-call loop and nothing else. Send messages to any LL
   tools: [Alloy.Tool.Core.Read]
 )
 
-result.text #=> "The version is 0.10.0"
+result.text #=> "The version is 0.11.0"
 ```
 
 ## Why Alloy?
@@ -70,7 +70,7 @@ Add `alloy` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:alloy, "~> 0.10"}
+    {:alloy, "~> 0.11"}
   ]
 end
 ```
@@ -118,7 +118,7 @@ Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAI, api_key: "...", m
 Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.Gemini, api_key: "...", model: "gemini-2.5-flash"}} | opts])
 
 # xAI via Responses-compatible API
-Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAI, api_key: "...", api_url: "https://api.x.ai", model: "grok-4"}} | opts])
+Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAI, api_key: "...", api_url: "https://api.x.ai", model: "grok-4.20-0309-reasoning"}} | opts])
 
 # xAI via chat completions (reasoning models, extra_body)
 Alloy.run("Read mix.exs", [{:provider, {Alloy.Provider.OpenAICompat, api_key: "...", api_url: "https://api.x.ai", model: "grok-4.1-fast-reasoning"}} | opts])
@@ -173,7 +173,7 @@ Results expose provider-owned state in `result.metadata.provider_state`:
     provider: {Alloy.Provider.OpenAI,
       api_key: System.get_env("XAI_API_KEY"),
       api_url: "https://api.x.ai",
-      model: "grok-4",
+      model: "grok-4.20-0309-reasoning",
       store: true
     }
   )
@@ -191,7 +191,7 @@ provider-native conversation:
     provider: {Alloy.Provider.OpenAI,
       api_key: System.get_env("XAI_API_KEY"),
       api_url: "https://api.x.ai",
-      model: "grok-4",
+      model: "grok-4.20-0309-reasoning",
       provider_state: provider_state
     }
   )
@@ -210,7 +210,7 @@ For xAI search tools:
     provider: {Alloy.Provider.OpenAI,
       api_key: System.get_env("XAI_API_KEY"),
       api_url: "https://api.x.ai",
-      model: "grok-4",
+      model: "grok-4.20-0309-reasoning",
       web_search: %{allowed_domains: ["docs.x.ai"]},
       include: ["inline_citations"]
     }
@@ -455,7 +455,7 @@ end
 | Anthropic | `Alloy.Provider.Anthropic` | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
 | Gemini | `Alloy.Provider.Gemini` | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3-pro-preview` |
 | OpenAI | `Alloy.Provider.OpenAI` | `gpt-5.4` |
-| xAI | `Alloy.Provider.OpenAI` with `api_url: "https://api.x.ai"` | `grok-4`, `grok-4.1-fast`, `grok-4-fast-reasoning`, `grok-code-fast-1` |
+| xAI | `Alloy.Provider.OpenAI` with `api_url: "https://api.x.ai"` | `grok-4.20-0309-reasoning`, `grok-4.20-multi-agent-0309`, `grok-4.1-fast-reasoning`, `grok-code-fast-1` |
 | Other OpenAI-compatible APIs | `Alloy.Provider.OpenAICompat` | Ollama, OpenRouter, DeepSeek, Mistral, Groq, Together |
 
 Use `Alloy.Provider.OpenAI` for native Responses APIs like OpenAI and xAI.

--- a/lib/alloy/provider/anthropic.ex
+++ b/lib/alloy/provider/anthropic.ex
@@ -53,7 +53,27 @@ defmodule Alloy.Provider.Anthropic do
   @code_execution_tool_type "code_execution_20250825"
   @code_execution_beta "code-execution-2025-08-25"
 
+  @typedoc """
+  Configuration for the Anthropic provider. See the module doc for field
+  semantics.
+  """
+  @type config :: %{
+          required(:api_key) => String.t(),
+          required(:model) => String.t(),
+          optional(:max_tokens) => pos_integer(),
+          optional(:system_prompt) => String.t(),
+          optional(:api_url) => String.t(),
+          optional(:api_version) => String.t(),
+          optional(:extra_headers) => [{String.t(), String.t()}],
+          optional(:req_options) => keyword(),
+          optional(:extended_thinking) => keyword(),
+          optional(:on_event) => (term() -> :ok),
+          optional(:cache) => boolean()
+        }
+
   @impl true
+  @spec complete([Message.t()], [Alloy.Provider.tool_def()], config()) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def complete(messages, tool_defs, config) do
     body = build_request_body(messages, tool_defs, config)
 
@@ -86,6 +106,8 @@ defmodule Alloy.Provider.Anthropic do
   as `complete/3` once the stream finishes.
   """
   @impl true
+  @spec stream([Message.t()], [Alloy.Provider.tool_def()], config(), (String.t() -> :ok)) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def stream(messages, tool_defs, config, on_chunk) when is_function(on_chunk, 1) do
     body =
       build_request_body(messages, tool_defs, config)

--- a/lib/alloy/provider/gemini.ex
+++ b/lib/alloy/provider/gemini.ex
@@ -41,7 +41,27 @@ defmodule Alloy.Provider.Gemini do
   @default_api_version "v1beta"
   @default_max_tokens 4096
 
+  @typedoc """
+  Configuration for the Gemini provider. See the module doc for field
+  semantics.
+  """
+  @type config :: %{
+          required(:api_key) => String.t(),
+          required(:model) => String.t(),
+          optional(:max_tokens) => pos_integer(),
+          optional(:system_prompt) => String.t(),
+          optional(:api_url) => String.t(),
+          optional(:api_version) => String.t(),
+          optional(:generation_config) => map(),
+          optional(:tool_config) => map(),
+          optional(:safety_settings) => [map()],
+          optional(:extra_headers) => [{String.t(), String.t()}],
+          optional(:req_options) => keyword()
+        }
+
   @impl true
+  @spec complete([Message.t()], [Alloy.Provider.tool_def()], config()) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def complete(messages, tool_defs, config) do
     body = build_request_body(messages, tool_defs, config)
 
@@ -67,6 +87,8 @@ defmodule Alloy.Provider.Gemini do
   end
 
   @impl true
+  @spec stream([Message.t()], [Alloy.Provider.tool_def()], config(), (String.t() -> :ok)) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def stream(messages, tool_defs, config, on_chunk) when is_function(on_chunk, 1) do
     body = build_request_body(messages, tool_defs, config)
 

--- a/lib/alloy/provider/openai.ex
+++ b/lib/alloy/provider/openai.ex
@@ -56,7 +56,31 @@ defmodule Alloy.Provider.OpenAI do
   @default_api_url "https://api.openai.com"
   @default_max_tokens 4096
 
+  @typedoc """
+  Configuration for the OpenAI provider. See the module doc for field
+  semantics.
+  """
+  @type config :: %{
+          required(:api_key) => String.t(),
+          required(:model) => String.t(),
+          optional(:max_tokens) => pos_integer(),
+          optional(:system_prompt) => String.t(),
+          optional(:api_url) => String.t(),
+          optional(:provider_state) => map(),
+          optional(:store) => boolean(),
+          optional(:include) => [String.t()],
+          optional(:tool_choice) => String.t() | map(),
+          optional(:parallel_tool_calls) => boolean(),
+          optional(:previous_response_id) => String.t(),
+          optional(:built_in_tools) => [map()],
+          optional(:web_search) => boolean() | map(),
+          optional(:x_search) => boolean() | map(),
+          optional(:req_options) => keyword()
+        }
+
   @impl true
+  @spec complete([Message.t()], [Alloy.Provider.tool_def()], config()) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def complete(messages, tool_defs, config) do
     body = build_request_body(messages, tool_defs, config)
 
@@ -85,6 +109,8 @@ defmodule Alloy.Provider.OpenAI do
   end
 
   @impl true
+  @spec stream([Message.t()], [Alloy.Provider.tool_def()], config(), (String.t() -> :ok)) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def stream(messages, tool_defs, config, on_chunk) when is_function(on_chunk, 1) do
     body =
       messages

--- a/lib/alloy/provider/openai_compat.ex
+++ b/lib/alloy/provider/openai_compat.ex
@@ -57,7 +57,25 @@ defmodule Alloy.Provider.OpenAICompat do
   @default_max_tokens 4096
   @default_chat_path "/v1/chat/completions"
 
+  @typedoc """
+  Configuration for the OpenAI-compatible provider. `:api_key` is optional
+  (omit for local providers like Ollama). See the module doc for field
+  semantics.
+  """
+  @type config :: %{
+          required(:api_url) => String.t(),
+          required(:model) => String.t(),
+          optional(:api_key) => String.t(),
+          optional(:max_tokens) => pos_integer(),
+          optional(:system_prompt) => String.t(),
+          optional(:chat_path) => String.t(),
+          optional(:extra_headers) => [{String.t(), String.t()}],
+          optional(:req_options) => keyword()
+        }
+
   @impl true
+  @spec complete([Message.t()], [Alloy.Provider.tool_def()], config()) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def complete(messages, tool_defs, config) do
     body = build_request_body(messages, tool_defs, config)
     url = "#{config.api_url}#{Map.get(config, :chat_path, @default_chat_path)}"
@@ -84,6 +102,8 @@ defmodule Alloy.Provider.OpenAICompat do
   end
 
   @impl true
+  @spec stream([Message.t()], [Alloy.Provider.tool_def()], config(), (String.t() -> :ok)) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def stream(messages, tool_defs, config, on_chunk) when is_function(on_chunk, 1) do
     body = build_request_body(messages, tool_defs, config)
     url = "#{config.api_url}#{Map.get(config, :chat_path, @default_chat_path)}"

--- a/lib/alloy/provider/xai.ex
+++ b/lib/alloy/provider/xai.ex
@@ -40,16 +40,28 @@ defmodule Alloy.Provider.XAI do
 
   @behaviour Alloy.Provider
 
+  alias Alloy.Message
   alias Alloy.Provider.OpenAI
 
   @xai_api_url "https://api.x.ai"
 
+  @typedoc """
+  Configuration for the xAI provider. Inherits the full `Alloy.Provider.OpenAI`
+  config surface plus `:web_search` and `:x_search` for Grok's native search
+  tools. `:api_url` defaults to `"https://api.x.ai"`.
+  """
+  @type config :: OpenAI.config()
+
   @impl true
+  @spec complete([Message.t()], [Alloy.Provider.tool_def()], config()) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def complete(messages, tool_defs, config) do
     OpenAI.complete(messages, tool_defs, with_defaults(config))
   end
 
   @impl true
+  @spec stream([Message.t()], [Alloy.Provider.tool_def()], config(), (String.t() -> :ok)) ::
+          {:ok, Alloy.Provider.completion_response()} | {:error, term()}
   def stream(messages, tool_defs, config, on_chunk) when is_function(on_chunk, 1) do
     OpenAI.stream(messages, tool_defs, with_defaults(config), on_chunk)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.10.2"
+  @version "0.11.0"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do


### PR DESCRIPTION
## Summary

Batches two changes into the \`0.11.0\` release:

1. **Provider typespec parity** — this PR
2. **grok-4.20 catalog entry** — already on main (PR #32)

The CHANGELOG and version bump reflect both.

## Why 0.11.0 (minor, not patch)

The new typespecs are user-visible via dialyzer — consumers who type-check their config maps will now get errors at call sites for typos and shape mismatches on all six providers. That's not strictly breaking (invalid configs failed at runtime before), but it's visible enough to warrant a minor bump rather than a patch.

## Provider typespec parity

Before this PR, only \`Alloy.Provider.Codex\` had typespecs on its public API:

| Provider | \`@spec\` | \`@type\` |
|---|---|---|
| codex.ex | 2 ✓ | 1 ✓ |
| anthropic.ex | 0 | 0 |
| gemini.ex | 0 | 0 |
| openai.ex | 0 | 0 |
| openai_compat.ex | 0 | 0 |
| xai.ex | 0 | 0 |

After this PR, all six match:

| Provider | \`@spec\` | \`@type\` |
|---|---|---|
| All six | 2 ✓ | 1 ✓ |

### Config types faithfully track the moduledoc

Each provider's \`@type config\` enumerates every option documented in its moduledoc, with proper types:

- **Anthropic**: adds \`:extended_thinking\` (keyword), \`:on_event\` (function), \`:cache\` (boolean), etc.
- **Gemini**: covers \`:generation_config\`, \`:tool_config\`, \`:safety_settings\` as maps.
- **OpenAI**: the widest surface — covers provider-state plumbing (\`:provider_state\`, \`:previous_response_id\`), native tools (\`:web_search\`, \`:x_search\`, \`:built_in_tools\`), and Responses API controls (\`:store\`, \`:include\`, \`:tool_choice\`, \`:parallel_tool_calls\`).
- **OpenAICompat**: correctly models the \`:api_url\` required / \`:api_key\` optional inversion for local-only providers like Ollama.
- **XAI**: aliased to \`Alloy.Provider.OpenAI.config()\` since it's a thin wrapper that inherits the full OpenAI surface.

## Test plan

- [x] \`mix format --check-formatted\`
- [x] \`mix compile --warnings-as-errors\` — clean
- [x] \`mix credo --strict\` — 996 mods/funs, 0 issues
- [x] \`mix test\` — 569 tests, 0 failures
- [x] \`mix dialyzer\` — 0 errors (PLT re-built with new specs)

## Release flow

Merge this PR, then:

\`\`\`
git tag v0.11.0
git push origin v0.11.0
\`\`\`

That triggers \`publish.yml\` which tests and publishes to Hex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)