### PR TITLE
chore: 0.12.1 — soft-deprecate runtime modules (paired with alloy_agent 0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2026-04-24
+
+### Deprecated
+
+- **`Alloy.Agent.Server`**, **`Alloy.Session`**, and **`Alloy.Agent.Events`** now emit compile-time deprecation warnings. These modules moved to the new [`alloy_agent`](https://hex.pm/packages/alloy_agent) package as `AlloyAgent.Server`, `AlloyAgent.Session`, and `AlloyAgent.Events`. The copies in Alloy will be **removed in 0.13.0**.
+
+### Why
+
+Alloy is refocusing as a protocol library: the loop, providers, tools, memory behaviour, message types. Runtime concerns (supervised processes, sessions, async dispatch, PubSub, backpressure, default memory stores) belong in the application layer, where OTP already gives you the primitives. `alloy_agent` is the opt-in runtime wrapper for users who want a supervised agent without wiring a GenServer themselves.
+
+Elixir's value proposition here is stronger than in Python or TypeScript: the BEAM already is the runtime. A protocol library that composes *with* OTP beats a runtime library that competes with it.
+
+### Migration
+
+Add `{:alloy_agent, "~> 0.1"}` to your deps, then:
+
+| Before (Alloy 0.12.0) | After (alloy_agent 0.1.0) |
+|---|---|
+| `alias Alloy.Agent.Server` | `alias AlloyAgent.Server` (or just `alias AlloyAgent`) |
+| `%Alloy.Session{}` | `%AlloyAgent.Session{}` |
+| `Alloy.Session.new/1` | `AlloyAgent.Session.new/1` |
+| `Alloy.send_message/3` | `AlloyAgent.send_message/3` |
+| `Alloy.cancel_request/2` | `AlloyAgent.cancel_request/2` |
+
+Code that uses only `Alloy.run/2`, `Alloy.stream/3`, tools, providers, messages, or the memory behaviour needs **no changes**.
+
+### Not changed
+
+- No runtime behaviour change in this release. The deprecated modules work exactly as they did in 0.12.0. This is a soft-migration patch — you have until Alloy 0.13.0 to move your imports.
+
 ## [0.12.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- **`Alloy.Agent.Server`**, **`Alloy.Session`**, and **`Alloy.Agent.Events`** now emit compile-time deprecation warnings. These modules moved to the new [`alloy_agent`](https://hex.pm/packages/alloy_agent) package as `AlloyAgent.Server`, `AlloyAgent.Session`, and `AlloyAgent.Events`. The copies in Alloy will be **removed in 0.13.0**.
+- **`Alloy.Agent.Server`**, **`Alloy.Session`**, and **`Alloy.Agent.Events`** are now documented as deprecated in HexDocs (warning admonitions on each `@moduledoc`). These modules moved to the new [`alloy_agent`](https://hex.pm/packages/alloy_agent) package as `AlloyAgent.Server`, `AlloyAgent.Session`, and `AlloyAgent.Events`. The copies in Alloy continue to work unchanged in 0.12.x and will be **removed in 0.13.0**.
+
+> **No `@deprecated` attribute / compile-time warnings yet.** The protocol loop (`Alloy.Agent.Turn`) still calls `Alloy.Agent.Events` internally, so adding `@deprecated` would break `mix compile --warnings-as-errors` for Alloy itself. The protocol/runtime split for events will be tightened in a follow-up patch ahead of 0.13.0; in the meantime, the HexDocs admonitions and the migration table below are the migration signal.
 
 ### Why
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Add `alloy` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:alloy, "~> 0.12"}
+    {:alloy, "~> 0.12"},
+    # Optional: supervised runtime wrapper (sessions, async dispatch, memory stores)
+    {:alloy_agent, "~> 0.1"}
   ]
 end
 ```

--- a/docs/MIGRATION-alloy_agent.md
+++ b/docs/MIGRATION-alloy_agent.md
@@ -1,0 +1,136 @@
+# Migrating runtime concerns to `alloy_agent`
+
+Alloy 0.12.1 marks `Alloy.Agent.Server`, `Alloy.Session`, and
+`Alloy.Agent.Events` as moved to the new
+[`alloy_agent`](https://hex.pm/packages/alloy_agent) package. These
+modules continue to work in 0.12.x but will be **removed in Alloy 0.13.0**.
+
+This doc is the migration you want to run now — once, mechanically,
+across your codebase — rather than hit the hard break in 0.13.
+
+## Why the split
+
+Alloy is refocusing as a protocol library: the loop
+(`Alloy.run/2`, `Alloy.stream/3`), the provider behaviour, the tool
+behaviour, the memory behaviour, the message types. Everything that
+speaks the wire.
+
+Runtime concerns — supervised processes, sessions, async dispatch,
+PubSub broadcast, backpressure queues, cost guards, fallback provider
+chains, default memory stores — belong above the protocol. They lived
+in Alloy because the split wasn't clean yet; they now live in their
+own package so you can opt in.
+
+The Elixir-specific argument: OTP *is* the runtime. `Phoenix.PubSub`,
+`Task.Supervisor`, `Registry`, `GenStage` are primitives every Elixir
+developer already knows. A protocol library that composes *with* OTP
+is more valuable here than a runtime library that competes with it.
+
+## Who needs to migrate
+
+If your code touches any of these, yes:
+
+- `alias Alloy.Agent.Server`
+- `%Alloy.Session{}` as a struct
+- `Alloy.Session.new/1` or `Alloy.Session.update_from_result/2`
+- `Alloy.Agent.Events` (module rarely used directly)
+- `Alloy.send_message/3`, `Alloy.cancel_request/2` (delegates)
+
+If you only use `Alloy.run/2`, `Alloy.stream/3`, tools, providers,
+messages, results, or the memory behaviour — no changes needed.
+
+## The migration
+
+### 1. Add the dep
+
+```elixir
+# mix.exs
+def deps do
+  [
+    {:alloy, "~> 0.12"},
+    {:alloy_agent, "~> 0.1"}
+  ]
+end
+```
+
+Then `mix deps.get`.
+
+### 2. Mechanical find/replace
+
+| Before | After |
+|---|---|
+| `alias Alloy.Agent.Server` | `alias AlloyAgent.Server` (or `alias AlloyAgent`) |
+| `Alloy.Agent.Server.start_link(...)` | `AlloyAgent.start_link(...)` |
+| `Alloy.Agent.Server.chat(pid, msg)` | `AlloyAgent.chat(pid, msg)` |
+| `Alloy.Agent.Server.stream_chat(...)` | `AlloyAgent.stream_chat(...)` |
+| `Alloy.Agent.Server.send_message(...)` | `AlloyAgent.send_message(...)` |
+| `Alloy.Agent.Server.cancel_request(...)` | `AlloyAgent.cancel_request(...)` |
+| `Alloy.Agent.Server.export_session(pid)` | `AlloyAgent.export_session(pid)` |
+| `Alloy.send_message/3` | `AlloyAgent.send_message/3` |
+| `Alloy.cancel_request/2` | `AlloyAgent.cancel_request/2` |
+| `%Alloy.Session{...}` | `%AlloyAgent.Session{...}` |
+| `Alloy.Session.new/1` | `AlloyAgent.Session.new/1` |
+| `Alloy.Session.update_from_result/2` | `AlloyAgent.Session.update_from_result/2` |
+| `Alloy.Session.t()` (typespec) | `AlloyAgent.Session.t()` |
+| `alias Alloy.Agent.Events` (rare) | `alias AlloyAgent.Events` |
+
+The `Alloy.Agent.{Config, State, Turn}` modules are **internal** loop
+mechanics and stay in Alloy — don't rename those. You're unlikely to
+import them directly anyway.
+
+### 3. Default memory stores (new in alloy_agent 0.1.0)
+
+If you're using Anthropic's memory tool (added in Alloy 0.12.0) and
+writing your own store, `alloy_agent` ships two reference
+implementations:
+
+```elixir
+# Process-local, dies with the store process
+{:ok, mem_pid} = AlloyAgent.Memory.InMemory.start_link()
+memory = {AlloyAgent.Memory.InMemory, mem_pid}
+
+# Filesystem-backed, survives restarts, session-scoped
+memory = AlloyAgent.Memory.Disk.new(
+  root: "/var/agent/memories",
+  session_id: "acct-42"
+)
+
+# Either works with both Alloy.run/2 and AlloyAgent.start_link/1:
+Alloy.run("Remember my preferences",
+  provider: {Alloy.Provider.Anthropic, ...},
+  memory: memory
+)
+```
+
+For production-grade storage (Postgres via Ecto, S3, Redis, encrypted
+at rest), implement `Alloy.Memory` yourself — the behaviour is six
+callbacks.
+
+## What happens if I don't migrate
+
+Your code keeps working through the entire Alloy 0.12.x line. When
+Alloy 0.13.0 lands, the `Alloy.Agent.Server`, `Alloy.Session`, and
+`Alloy.Agent.Events` modules will be removed — imports referencing
+them will fail to compile. Plan your upgrade window accordingly.
+
+## Questions worth asking after migrating
+
+- **Do you still need the GenServer wrapper?** Some use cases
+  (LiveView streaming, Phoenix controllers) suit `Alloy.run/2` + your
+  own supervision better than `AlloyAgent.Server`. The wrapper is
+  there when you want it — it's not the default.
+- **Is there runtime policy in your app that should be middleware?**
+  `max_budget_cents`, `fallback_providers`, and session lifecycle
+  hooks are supported in `AlloyAgent.Server` but could also be
+  expressed as `Alloy.Middleware` implementations — sometimes cleaner.
+- **Do you have your own memory store that duplicates
+  `AlloyAgent.Memory.Disk`?** Worth checking — using the shipped one
+  saves code, unless you have requirements (encryption, multi-tenant
+  paths, audit logs) it doesn't meet.
+
+## Reporting issues
+
+File against [alloy](https://github.com/alloy-ex/alloy/issues) if the
+question is about the protocol, or
+[alloy_agent](https://github.com/alloy-ex/alloy_agent/issues) if it's
+about the runtime.

--- a/lib/alloy/agent/events.ex
+++ b/lib/alloy/agent/events.ex
@@ -2,9 +2,16 @@ defmodule Alloy.Agent.Events do
   @moduledoc """
   Event envelope construction and runtime opts normalization.
 
+  > #### Moved to `alloy_agent` {: .warning}
+  >
+  > This module has moved to `AlloyAgent.Events` in the
+  > [`alloy_agent`](https://hex.pm/packages/alloy_agent) package. This
+  > copy will be removed in Alloy 0.13.0. The v1 envelope protocol is
+  > a runtime-layer concern; Alloy's loop still emits raw telemetry
+  > via `:telemetry.execute/3`.
+
   Builds v1 event envelopes, manages sequence counters, and derives
-  correlation IDs. Extracted from `Alloy.Agent.Turn` to separate
-  event plumbing from agent loop control flow.
+  correlation IDs.
   """
 
   alias Alloy.Agent.State

--- a/lib/alloy/agent/server.ex
+++ b/lib/alloy/agent/server.ex
@@ -2,6 +2,21 @@ defmodule Alloy.Agent.Server do
   @moduledoc """
   OTP-backed persistent agent process.
 
+  > #### Moved to `alloy_agent` {: .warning}
+  >
+  > This module has moved to `AlloyAgent.Server` in the
+  > [`alloy_agent`](https://hex.pm/packages/alloy_agent) package. This
+  > copy will be removed in Alloy 0.13.0. Migrate by adding
+  > `{:alloy_agent, "~> 0.1"}` to your deps and changing
+  > `alias Alloy.Agent.Server` to `alias AlloyAgent.Server` (or `alias AlloyAgent`).
+  >
+  > Why: Alloy is refocusing as a protocol library — the loop, providers,
+  > tools, memory behaviour, message types. Runtime concerns (supervised
+  > processes, sessions, async dispatch, PubSub, backpressure, default
+  > memory stores) belong in the app layer, where OTP already gives you
+  > the primitives. `alloy_agent` is the opt-in runtime for users who
+  > want a supervised agent without wiring a GenServer themselves.
+
   Wraps the stateless `Turn.run_loop/1` in a GenServer so the agent
   can hold conversation history across multiple calls, be supervised,
   and run concurrently with other agents.

--- a/lib/alloy/session.ex
+++ b/lib/alloy/session.ex
@@ -2,6 +2,14 @@ defmodule Alloy.Session do
   @moduledoc """
   Serializable session container.
 
+  > #### Moved to `alloy_agent` {: .warning}
+  >
+  > This struct has moved to `AlloyAgent.Session` in the
+  > [`alloy_agent`](https://hex.pm/packages/alloy_agent) package. This
+  > copy will be removed in Alloy 0.13.0. Migrate by replacing
+  > `%Alloy.Session{}` with `%AlloyAgent.Session{}` and
+  > `Alloy.Session.new/1` with `AlloyAgent.Session.new/1`.
+
   Wraps the conversation state in a format that can be serialized
   to JSON, stored in a database, or passed between processes.
   No database required — sessions are plain structs.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.12.1"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do


### PR DESCRIPTION
## Summary

Companion release to the new [\`alloy_agent\`](https://github.com/alloy-ex/alloy_agent) package, which extracts Alloy's runtime concerns into a separate hex package so Alloy can refocus as a protocol library.

## What this PR does

- Adds **\"Moved to alloy_agent\"** banners to the moduledocs of \`Alloy.Agent.Server\`, \`Alloy.Session\`, and \`Alloy.Agent.Events\`.
- Bumps to \`0.12.1\`.
- Adds \`docs/MIGRATION-alloy_agent.md\` with a mechanical find/replace table for consumers.
- README flags \`alloy_agent\` as an optional dep.

## What this PR does NOT do

- **No code changes to the deprecated modules** — they work exactly as in 0.12.0.
- **No compile-time \`@deprecated\` attributes yet.** They'd trigger noisy warnings on every internal self-reference (\`Agent.Server\` uses \`Session\`, etc.). That kind of compile-error-on-self-use wants the hard-removal release — coming in 0.13.0.
- **No changes to \`Alloy.run/2\`, providers, tools, memory, messages.** The protocol library surface is completely unchanged.

## Why the split

Alloy is refocusing as a protocol library: loop, providers, tools, memory behaviour, message types. Runtime concerns (supervised GenServer, sessions, async dispatch, PubSub broadcast, backpressure queues, cost guards, fallback provider chains, default memory stores) belong above the protocol so consumers can opt in.

The Elixir-specific argument: **OTP is the runtime.** \`Phoenix.PubSub\`, \`Task.Supervisor\`, \`Registry\`, \`GenStage\` are primitives every Elixir developer already knows. A protocol library that composes *with* OTP is more valuable here than a runtime library that competes with it.

See \`docs/MIGRATION-alloy_agent.md\` for the full migration.

## Timeline

| Release | Scope |
|---|---|
| **0.12.1 (this PR)** | Soft migration. Moduledoc banners, new package available, everything keeps working. |
| **0.13.0 (follow-up)** | Hard removal. \`Alloy.Agent.Server\`, \`Alloy.Session\`, \`Alloy.Agent.Events\` deleted. \`Config\`/\`State\` trimmed of runtime-only fields. Breaking for consumers that haven't migrated. |

Users who migrate imports during the 0.12.x window hit zero breaking changes when 0.13 lands.

## Companion PR

[alloy-ex/alloy_agent](https://github.com/alloy-ex/alloy_agent) — initial commit with the extracted modules. Publishing to Hex pending HEX_API_KEY secret on the new repo + your review of this pair.

## Test plan

- [x] \`mix format --check-formatted\` — clean
- [x] \`mix compile --warnings-as-errors\` — clean
- [x] \`mix credo --strict\` — 1037 mods/funs, 0 issues
- [x] \`mix test\` — 587 tests pass (no behavioural changes)
- [x] alloy_agent repo: 22 tests pass (session, memory InMemory, memory Disk, API surface, Server smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)