### PR TITLE
ci: bump actions/checkout + actions/cache to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             otp: "27"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: erlef/setup-beam@v1
         with:
@@ -31,7 +31,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
 
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -40,7 +40,7 @@ jobs:
           restore-keys: ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
 
       - name: Cache PLT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: priv/plts
           key: ${{ runner.os }}-plt-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('mix.lock') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: erlef/setup-beam@v1
         with:
@@ -25,7 +25,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -47,7 +47,7 @@ jobs:
       ALLOY_WEBSITE_SYNC_TOKEN: ${{ secrets.ALLOY_WEBSITE_SYNC_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: erlef/setup-beam@v1
         with:
@@ -55,7 +55,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` v4 → v5 across both workflows (3 call sites)
- Bumps `actions/cache` v4 → v5 across both workflows (4 call sites, including PLT cache)
- Silences the Node.js 20 deprecation warning that surfaced on the `v0.12.1` publish run

## Why now

GitHub deprecated Node.js 20 actions on 2025-09-19. From **2026-06-02** new runs default to Node 24; from **2026-09-16** Node 20 is removed entirely. The v5 majors of both actions ship on Node 24 and are drop-in for the call sites we use (no input/output schema changes for `checkout` or for the `path/key/restore-keys` cache shape).

## Test plan

- [ ] CI workflow runs green on this PR (proves the v5 bump works for `ci.yml`)
- [ ] Verify cache hit/miss telemetry looks normal on first run (cache key format unchanged, so existing caches should still match — `actions/cache@v5` is backwards-compatible with v4-written entries)
- [ ] Publish workflow change is exercised on the next tag push (no way to test without cutting a release; verified by inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)