### PR TITLE
feat: 0.12.2 — promote Events to Alloy.Events (correct 0.12.1 deprecation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2026-04-26
+
+### Changed
+
+- **`Alloy.Events`** is the new canonical module for v1 event envelope construction. The implementation moved from `Alloy.Agent.Events` to the top-level namespace because `Alloy.Agent.Turn` (the protocol loop) calls it directly — anything Turn calls is, by definition, part of Alloy's protocol surface, not a runtime concern.
+- **`Alloy.Agent.Events`** is now a `@deprecated` thin shim that delegates to `Alloy.Events`. External callers receive compile-time deprecation warnings and should switch their `alias` lines from `Alloy.Agent.Events` to `Alloy.Events`. The shim will be removed in Alloy 0.13.0.
+
+### Corrected
+
+- **Retracts the 0.12.1 guidance to migrate `Alloy.Agent.Events` → `AlloyAgent.Events`.** That guidance was wrong: `Alloy.Agent.Turn` depends on event envelope construction, so the v1 envelope format is protocol-layer (stays in Alloy), not runtime-layer (move to `alloy_agent`). The migration table in `docs/MIGRATION-alloy_agent.md` has been updated to point at `Alloy.Events` instead. Users who already migrated to `AlloyAgent.Events` based on 0.12.1 should switch back to `Alloy.Events`; the two implementations are byte-equivalent today, but only `Alloy.Events` will receive future protocol updates.
+- **`Alloy.Agent.Server`** and **`Alloy.Session`** deprecation guidance is unchanged — those modules still move to `alloy_agent` as `AlloyAgent.Server` and `AlloyAgent.Session` (they are runtime concerns Turn doesn't depend on).
+
 ## [0.12.1] - 2026-04-24
 
 ### Deprecated

--- a/docs/MIGRATION-alloy_agent.md
+++ b/docs/MIGRATION-alloy_agent.md
@@ -33,8 +33,11 @@ If your code touches any of these, yes:
 - `alias Alloy.Agent.Server`
 - `%Alloy.Session{}` as a struct
 - `Alloy.Session.new/1` or `Alloy.Session.update_from_result/2`
-- `Alloy.Agent.Events` (module rarely used directly)
 - `Alloy.send_message/3`, `Alloy.cancel_request/2` (delegates)
+
+If your code uses `Alloy.Agent.Events`, see the **0.12.2 correction**
+below — that module is now `Alloy.Events` (still in Alloy), not
+`AlloyAgent.Events`.
 
 If you only use `Alloy.run/2`, `Alloy.stream/3`, tools, providers,
 messages, results, or the memory behaviour — no changes needed.
@@ -72,11 +75,34 @@ Then `mix deps.get`.
 | `Alloy.Session.new/1` | `AlloyAgent.Session.new/1` |
 | `Alloy.Session.update_from_result/2` | `AlloyAgent.Session.update_from_result/2` |
 | `Alloy.Session.t()` (typespec) | `AlloyAgent.Session.t()` |
-| `alias Alloy.Agent.Events` (rare) | `alias AlloyAgent.Events` |
+| `alias Alloy.Agent.Events` (rare) | `alias Alloy.Events` *(corrected in 0.12.2 — see below)* |
 
 The `Alloy.Agent.{Config, State, Turn}` modules are **internal** loop
 mechanics and stay in Alloy — don't rename those. You're unlikely to
 import them directly anyway.
+
+#### Correction in Alloy 0.12.2: `Alloy.Agent.Events` stays in Alloy
+
+Alloy 0.12.1 listed `Alloy.Agent.Events` as moving to
+`AlloyAgent.Events`. **That guidance was wrong.** `Alloy.Agent.Turn`
+(the protocol loop) calls event envelope construction directly, so
+the v1 envelope format is part of Alloy's protocol surface — not a
+runtime concern. In Alloy 0.12.2 the canonical implementation lives
+at `Alloy.Events`; `Alloy.Agent.Events` is a `@deprecated` thin shim
+that delegates to it and will be removed in 0.13.0.
+
+If you migrated to `AlloyAgent.Events` based on the 0.12.1 guidance:
+switch back to `Alloy.Events`. The two implementations are
+byte-equivalent in 0.1.0 / 0.12.2, but only `Alloy.Events` will
+receive future protocol updates.
+
+```elixir
+# 0.12.1 said this — don't do this
+alias AlloyAgent.Events
+
+# 0.12.2 corrects to this
+alias Alloy.Events
+```
 
 ### 3. Default memory stores (new in alloy_agent 0.1.0)
 

--- a/lib/alloy/agent/events.ex
+++ b/lib/alloy/agent/events.ex
@@ -1,140 +1,33 @@
 defmodule Alloy.Agent.Events do
   @moduledoc """
-  Event envelope construction and runtime opts normalization.
+  Deprecated alias for `Alloy.Events`.
 
-  > #### Moved to `alloy_agent` {: .warning}
+  > #### Renamed to `Alloy.Events` {: .warning}
   >
-  > This module has moved to `AlloyAgent.Events` in the
-  > [`alloy_agent`](https://hex.pm/packages/alloy_agent) package. This
-  > copy will be removed in Alloy 0.13.0. The v1 envelope protocol is
-  > a runtime-layer concern; Alloy's loop still emits raw telemetry
-  > via `:telemetry.execute/3`.
-
-  Builds v1 event envelopes, manages sequence counters, and derives
-  correlation IDs.
+  > The v1 event envelope module has been promoted to the top-level
+  > namespace as `Alloy.Events`. It is part of Alloy's protocol surface
+  > — `Alloy.Agent.Turn` calls it directly, so it is **not** moving to
+  > the `alloy_agent` runtime package.
+  >
+  > This shim will be removed in Alloy 0.13.0. Update `alias` lines from
+  > `Alloy.Agent.Events` to `Alloy.Events`.
+  >
+  > Note: Alloy 0.12.1 incorrectly listed this module as moving to
+  > `AlloyAgent.Events`. That guidance was wrong and is retracted in
+  > 0.12.2 — see `docs/MIGRATION-alloy_agent.md` for the corrected table.
   """
 
   alias Alloy.Agent.State
 
-  @doc """
-  Normalize runtime opts for event emission.
-
-  Ensures `:on_event`, `:event_seq_ref`, and `:event_correlation_id`
-  are present in the opts keyword list.
-  """
+  @deprecated "Use Alloy.Events.normalize_opts/2 instead. Will be removed in Alloy 0.13.0."
   @spec normalize_opts(State.t(), keyword()) :: keyword()
-  def normalize_opts(%State{} = state, opts) do
-    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
+  defdelegate normalize_opts(state, opts), to: Alloy.Events
 
-    opts
-    |> Keyword.put(:on_event, on_event)
-    |> put_new_lazy(:event_seq_ref, fn -> :atomics.new(1, signed: false) end)
-    |> put_new_lazy(:event_correlation_id, fn -> build_correlation_id(state) end)
-  end
-
-  @doc """
-  Derive a correlation ID from the agent state's context.
-
-  Precedence: `context[:request_id]` > `context[:correlation_id]` >
-  generated from `agent_id`.
-  """
+  @deprecated "Use Alloy.Events.build_correlation_id/1 instead. Will be removed in Alloy 0.13.0."
   @spec build_correlation_id(State.t()) :: binary()
-  def build_correlation_id(%State{} = state) do
-    context = state.config.context
+  defdelegate build_correlation_id(state), to: Alloy.Events
 
-    cond do
-      is_binary(Map.get(context, :request_id)) ->
-        Map.get(context, :request_id)
-
-      is_binary(Map.get(context, :correlation_id)) ->
-        Map.get(context, :correlation_id)
-
-      true ->
-        state.agent_id <> ":" <> Base.url_encode64(:crypto.strong_rand_bytes(8), padding: false)
-    end
-  end
-
-  @doc """
-  Emit an event envelope.
-
-  Builds a v1 envelope from the raw event, calls the `on_event` callback,
-  and fires a `:telemetry` event.
-  """
+  @deprecated "Use Alloy.Events.emit/3 instead. Will be removed in Alloy 0.13.0."
   @spec emit(keyword(), non_neg_integer(), term()) :: :ok
-  def emit(opts, turn, raw_event) do
-    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
-    event_seq_ref = Keyword.get(opts, :event_seq_ref)
-    correlation_id = Keyword.get(opts, :event_correlation_id)
-
-    envelope = build_event_envelope(raw_event, event_seq_ref, correlation_id, turn)
-    on_event.(envelope)
-
-    :telemetry.execute(
-      [:alloy, :event],
-      %{seq: envelope.seq},
-      %{
-        v: envelope.v,
-        event: envelope.event,
-        correlation_id: envelope.correlation_id,
-        turn: envelope.turn
-      }
-    )
-  end
-
-  # ── Private ───────────────────────────────────────────────────────────────
-
-  defp build_event_envelope(%{v: 1} = envelope, _seq_ref, _correlation_id, _turn), do: envelope
-
-  defp build_event_envelope({event, payload}, seq_ref, correlation_id, turn)
-       when is_atom(event) do
-    {seq, effective_correlation_id, normalized_payload} =
-      normalize_event_fields(event, payload, seq_ref, correlation_id)
-
-    %{
-      v: 1,
-      seq: seq,
-      correlation_id: effective_correlation_id,
-      turn: turn,
-      ts_ms: System.system_time(:millisecond),
-      event: event,
-      payload: normalized_payload
-    }
-  end
-
-  defp build_event_envelope(raw_event, seq_ref, correlation_id, turn) do
-    %{
-      v: 1,
-      seq: next_event_seq(seq_ref),
-      correlation_id: correlation_id,
-      turn: turn,
-      ts_ms: System.system_time(:millisecond),
-      event: :runtime_event,
-      payload: raw_event
-    }
-  end
-
-  defp normalize_event_fields(event, payload, seq_ref, correlation_id)
-       when event in [:tool_start, :tool_end] and is_map(payload) do
-    seq = Map.get(payload, :event_seq) || next_event_seq(seq_ref)
-    effective_correlation_id = Map.get(payload, :correlation_id) || correlation_id
-    normalized_payload = Map.drop(payload, [:event_seq, :correlation_id])
-
-    {seq, effective_correlation_id, normalized_payload}
-  end
-
-  defp normalize_event_fields(_event, payload, seq_ref, correlation_id) do
-    {next_event_seq(seq_ref), correlation_id, payload}
-  end
-
-  defp next_event_seq(ref) do
-    :atomics.add_get(ref, 1, 1)
-  end
-
-  defp put_new_lazy(opts, key, producer) when is_list(opts) and is_function(producer, 0) do
-    if Keyword.has_key?(opts, key) do
-      opts
-    else
-      Keyword.put(opts, key, producer.())
-    end
-  end
+  defdelegate emit(opts, turn, raw_event), to: Alloy.Events
 end

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -8,8 +8,9 @@ defmodule Alloy.Agent.Turn do
   This is a pure function — no GenServer, no process overhead.
   """
 
-  alias Alloy.Agent.{Events, State}
+  alias Alloy.Agent.State
   alias Alloy.Context.Compactor
+  alias Alloy.Events
   alias Alloy.Memory.Router, as: MemoryRouter
   alias Alloy.{Message, Middleware}
   alias Alloy.Provider.Retry

--- a/lib/alloy/events.ex
+++ b/lib/alloy/events.ex
@@ -1,0 +1,136 @@
+defmodule Alloy.Events do
+  @moduledoc """
+  Event envelope construction and runtime opts normalization.
+
+  Builds v1 event envelopes, manages sequence counters, and derives
+  correlation IDs. Used by `Alloy.Agent.Turn` to wrap raw provider and
+  tool events into the versioned envelope shape exposed to `:on_event`
+  callbacks on `Alloy.run/2` and `Alloy.stream/3`.
+
+  The v1 envelope is part of the protocol surface — anything `Turn`
+  emits is something downstream consumers can rely on. `:telemetry`
+  events fired alongside the envelope are the lower-level analogue.
+  """
+
+  alias Alloy.Agent.State
+
+  @doc """
+  Normalize runtime opts for event emission.
+
+  Ensures `:on_event`, `:event_seq_ref`, and `:event_correlation_id`
+  are present in the opts keyword list.
+  """
+  @spec normalize_opts(State.t(), keyword()) :: keyword()
+  def normalize_opts(%State{} = state, opts) do
+    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
+
+    opts
+    |> Keyword.put(:on_event, on_event)
+    |> put_new_lazy(:event_seq_ref, fn -> :atomics.new(1, signed: false) end)
+    |> put_new_lazy(:event_correlation_id, fn -> build_correlation_id(state) end)
+  end
+
+  @doc """
+  Derive a correlation ID from the agent state's context.
+
+  Precedence: `context[:request_id]` > `context[:correlation_id]` >
+  generated from `agent_id`.
+  """
+  @spec build_correlation_id(State.t()) :: binary()
+  def build_correlation_id(%State{} = state) do
+    context = state.config.context
+
+    cond do
+      is_binary(Map.get(context, :request_id)) ->
+        Map.get(context, :request_id)
+
+      is_binary(Map.get(context, :correlation_id)) ->
+        Map.get(context, :correlation_id)
+
+      true ->
+        state.agent_id <> ":" <> Base.url_encode64(:crypto.strong_rand_bytes(8), padding: false)
+    end
+  end
+
+  @doc """
+  Emit an event envelope.
+
+  Builds a v1 envelope from the raw event, calls the `on_event` callback,
+  and fires a `:telemetry` event.
+  """
+  @spec emit(keyword(), non_neg_integer(), term()) :: :ok
+  def emit(opts, turn, raw_event) do
+    on_event = Keyword.get(opts, :on_event) || fn _event -> :ok end
+    event_seq_ref = Keyword.get(opts, :event_seq_ref)
+    correlation_id = Keyword.get(opts, :event_correlation_id)
+
+    envelope = build_event_envelope(raw_event, event_seq_ref, correlation_id, turn)
+    on_event.(envelope)
+
+    :telemetry.execute(
+      [:alloy, :event],
+      %{seq: envelope.seq},
+      %{
+        v: envelope.v,
+        event: envelope.event,
+        correlation_id: envelope.correlation_id,
+        turn: envelope.turn
+      }
+    )
+  end
+
+  defp build_event_envelope(%{v: 1} = envelope, _seq_ref, _correlation_id, _turn), do: envelope
+
+  defp build_event_envelope({event, payload}, seq_ref, correlation_id, turn)
+       when is_atom(event) do
+    {seq, effective_correlation_id, normalized_payload} =
+      normalize_event_fields(event, payload, seq_ref, correlation_id)
+
+    %{
+      v: 1,
+      seq: seq,
+      correlation_id: effective_correlation_id,
+      turn: turn,
+      ts_ms: System.system_time(:millisecond),
+      event: event,
+      payload: normalized_payload
+    }
+  end
+
+  defp build_event_envelope(raw_event, seq_ref, correlation_id, turn) do
+    %{
+      v: 1,
+      seq: next_event_seq(seq_ref),
+      correlation_id: correlation_id,
+      turn: turn,
+      ts_ms: System.system_time(:millisecond),
+      event: :runtime_event,
+      payload: raw_event
+    }
+  end
+
+  defp normalize_event_fields(event, payload, seq_ref, correlation_id)
+       when event in [:tool_start, :tool_end] and is_map(payload) do
+    seq = Map.get(payload, :event_seq) || next_event_seq(seq_ref)
+    effective_correlation_id = Map.get(payload, :correlation_id) || correlation_id
+    normalized_payload = Map.drop(payload, [:event_seq, :correlation_id])
+
+    {seq, effective_correlation_id, normalized_payload}
+  end
+
+  defp normalize_event_fields(_event, payload, seq_ref, correlation_id) do
+    {next_event_seq(seq_ref), correlation_id, payload}
+  end
+
+  defp next_event_seq(ref) do
+    :atomics.add_get(ref, 1, 1)
+  end
+
+  defp put_new_lazy(opts, key, producer) when is_list(opts) and is_function(producer, 0) do
+    if Keyword.has_key?(opts, key) do
+      opts
+    else
+      Keyword.put(opts, key, producer.())
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.12.1"
+  @version "0.12.2"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do


### PR DESCRIPTION
## Summary

- New canonical module \`Alloy.Events\` (\`lib/alloy/events.ex\`) for v1 event envelope construction
- \`Alloy.Agent.Events\` becomes a \`@deprecated\` thin shim that delegates to \`Alloy.Events\` (still removed in 0.13.0; only the destination changed)
- \`Alloy.Agent.Turn\` updated to call the new module
- CHANGELOG and \`docs/MIGRATION-alloy_agent.md\` retract the 0.12.1 guidance to migrate Events to \`alloy_agent\`

## Why

The 0.12.1 release deprecated \`Alloy.Agent.Events\` in favor of \`AlloyAgent.Events\`, classifying event envelope construction as a *runtime* concern. **That classification was wrong.** \`Alloy.Agent.Turn\` (the protocol loop) calls \`Events.normalize_opts/2\` and \`Events.emit/3\` directly — anything Turn calls is, by definition, part of Alloy's protocol surface. The v1 envelope shape is exposed via \`:on_event\` callbacks on \`Alloy.run/2\` and \`Alloy.stream/3\`, which is public protocol API.

Surfaced during self-review of #35: adding \`@deprecated\` attributes (the obvious next step from the docs-only deprecation in 0.12.1) caused \`mix compile --warnings-as-errors\` to fail because Turn's calls into Events tripped the warning. That's the call graph telling us Events isn't actually moving — it's protocol. This PR fixes the architectural classification at the source.

## Diff shape

\`\`\`
 CHANGELOG.md                  |  16 +++
 docs/MIGRATION-alloy_agent.md |  30 ++++++-
 lib/alloy/agent/events.ex     | 145 ++++--------------
 lib/alloy/agent/turn.ex       |   3 +-
 lib/alloy/events.ex           | 130 +++++++++++++++++ (new)
 mix.exs                       |   2 +-
\`\`\`

\`Alloy.Agent.Events\` shrinks from 140 lines to 30 (delegate shim). \`Alloy.Events\` is the new 130-line canonical home. \`Turn\` changed by one line (the alias).

## Migration impact for users

- **If you used \`Alloy.Agent.Events\`**: now warns at compile time. Switch your alias to \`Alloy.Events\`. Or do nothing — the shim works in 0.12.x; only 0.13.0 deletes it.
- **If you migrated to \`AlloyAgent.Events\` based on 0.12.1 guidance**: switch back to \`Alloy.Events\`. The two implementations are byte-equivalent today, but only \`Alloy.Events\` will receive future protocol updates. Realistic affected population is near-zero given 0.12.1 shipped two days ago.
- **If you don't use \`Events\` directly**: no changes needed. The \`:on_event\` callback envelope shape (\`v: 1\`, \`seq:\`, \`correlation_id:\`, \`turn:\`, \`ts_ms:\`, \`event:\`, \`payload:\`) is unchanged.

## Test plan

- [x] \`mix format --check-formatted\` ✓
- [x] \`mix compile --warnings-as-errors\` ✓ (no internal callers of deprecated shim)
- [x] \`mix credo --strict\` ✓
- [x] \`mix test\` — 587 tests, 0 failures ✓
- [x] \`mix dialyzer\` — 0 errors ✓
- [x] Pre-commit hook passed (which re-runs the above)
- [ ] CI green on this PR
- [ ] On merge: tag \`v0.12.2\` to trigger Hex publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)