### PR TITLE
feat(xai): add grok-4.3 family to the model catalog

### DIFF
--- a/lib/alloy/model_metadata.ex
+++ b/lib/alloy/model_metadata.ex
@@ -64,6 +64,8 @@ defmodule Alloy.ModelMetadata do
       limit: 2_000_000,
       suffix_patterns: [~r/^-\d{4}-(reasoning|non-reasoning)$/, ~r/^-multi-agent-\d{4}$/]
     },
+    # grok-4.3 — xAI frontier as of April 2026. Always-on reasoning (1M ctx).
+    %{name: "grok-4.3", limit: 1_000_000, suffix_patterns: [""]},
     # Dash notation (grok-4-1-fast-*) for backward compat
     %{name: "grok-4-1-fast-reasoning", limit: 2_000_000, suffix_patterns: [""]},
     %{name: "grok-4-1-fast-non-reasoning", limit: 2_000_000, suffix_patterns: [""]},

--- a/lib/alloy/provider/xai.ex
+++ b/lib/alloy/provider/xai.ex
@@ -9,7 +9,7 @@ defmodule Alloy.Provider.XAI do
 
   Required:
   - `:api_key` - xAI API key
-  - `:model` - Model name (e.g., `"grok-4.20-0309-reasoning"`,
+  - `:model` - Model name (e.g., `"grok-4.3"`,
     `"grok-4.1-fast-reasoning"`, `"grok-code-fast-1"`)
 
   Optional:
@@ -22,7 +22,7 @@ defmodule Alloy.Provider.XAI do
       Alloy.run("What's happening on X today?",
         provider: {Alloy.Provider.XAI,
           api_key: System.get_env("XAI_API_KEY"),
-          model: "grok-4.20-0309-reasoning",
+          model: "grok-4.3",
           web_search: true
         }
       )

--- a/test/alloy/model_metadata_test.exs
+++ b/test/alloy/model_metadata_test.exs
@@ -17,6 +17,8 @@ defmodule Alloy.ModelMetadataTest do
       assert ModelMetadata.context_window("grok-4.20-0309-reasoning") == 2_000_000
       assert ModelMetadata.context_window("grok-4.20-0309-non-reasoning") == 2_000_000
       assert ModelMetadata.context_window("grok-4.20-multi-agent-0309") == 2_000_000
+      # grok-4.3 — xAI frontier as of April 2026, 1M context window
+      assert ModelMetadata.context_window("grok-4.3") == 1_000_000
       # Kimi (Moonshot AI)
       assert ModelMetadata.context_window("kimi-k2.5") == 256_000
       assert ModelMetadata.context_window("kimi-k2.6") == 256_000


### PR DESCRIPTION
## Summary

Adds `grok-4.3` to `Alloy.ModelMetadata`. xAI launched Grok 4.3 for API access on 2026-04-30; it is now xAI's recommended frontier model.

**auto-detected by the daily Grok 4.3 API watch trigger**

### Model details

| Field | Value |
|---|---|
| Model ID | `grok-4.3` |
| Context window | 1,000,000 tokens |
| Reasoning | Always-on (built-in; `reasoning_effort` param not supported) |
| Source | https://docs.x.ai/developers/models/grok-4.3 |

### Why this matters

Without this entry the Compactor fell back to `@default_limit 200_000` instead of the real 1M window, causing premature compaction at ~200K tokens on every `grok-4.3` agent run — wasting 800K tokens of available context.

### Changes

- `lib/alloy/model_metadata.ex` — new entry: `%{name: "grok-4.3", limit: 1_000_000, suffix_patterns: [""]}`. Exact-match only (no date-stamped variants documented yet; follow-up PR when they appear).
- `test/alloy/model_metadata_test.exs` — one assertion locking in the 1M window for `grok-4.3`, placed next to the other grok-4.20 assertions.
- `lib/alloy/provider/xai.ex` — moduledoc example updated from `grok-4.20-0309-reasoning` to `grok-4.3` (new frontier).

## Test plan

- [ ] `mix format --check-formatted`
- [ ] `mix test test/alloy/model_metadata_test.exs`
- [ ] `mix credo --strict lib/alloy/model_metadata.ex lib/alloy/provider/xai.ex`

> Note: Elixir toolchain was not available in the trigger environment; CI should cover all three checks.

https://claude.ai/code/session_01WqCHcRebzNF4b34ZbdjJBx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqCHcRebzNF4b34ZbdjJBx)_