### PR TITLE
release: 0.12.4 — provider fidelity, cache-aware compaction, audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.4] - 2026-07-03
+
+### Fixed
+
+- **`Alloy.Testing` default tools now ship in Hex.** The default echo tool is
+  an inline `Alloy.Tool.Inline` instead of a `test/support` module.
+- **Signed thinking blocks are never truncated.** Deterministic fallback
+  compaction now drops signed thinking blocks instead of mutating provider
+  signatures.
+- **Tool crash results are model-legible.** Tool result errors are one
+  actionable line, while full stacktraces remain in logs and telemetry.
+- **Codex provider honors turn deadlines.** `:receive_timeout` now caps the
+  Codex port timeout and still kills the subprocess on expiry.
 
 ### Added
 
+- **Batched tool-result clearing before summary compaction.** Old
+  `tool_result` and `server_tool_result` content is cleared in one batch before
+  any summarizer call, with `:clear_tool_results`,
+  `:keep_recent_tool_results`, and `[:alloy, :compaction, :cleared]`
+  `bytes_cleared` telemetry.
 - **`:thinking` on `Alloy.Result`** (#36): a run result now surfaces the final
   assistant reasoning text alongside `:text`, so callers no longer have to dig
   it out of the last message's content blocks. Adds an `Alloy.Message.thinking/1`
   helper for per-message extraction.
+- **User-owned compaction prompts.** `:summary_system_prompt` and
+  `:summary_prompt` are now configurable under `compaction:`.
+- **OpenAI Responses reasoning persistence.** Stateless Responses calls request
+  `reasoning.encrypted_content`, preserve raw reasoning items, and round-trip
+  them before related function calls.
+- **Strict tool schemas.** Tools can opt into `strict?/0` or `strict: true`;
+  OpenAI, OpenAICompat, and Anthropic emit strict tool definitions, and Alloy
+  validates `additionalProperties: false`.
+- **Anthropic advanced tool-use metadata.** Tools can provide
+  `input_examples` and `defer_loading`; Anthropic emits the fields and merges
+  the `advanced-tool-use-2025-11-20` beta header when needed.
+- **Anthropic `extra_body` passthrough.** Provider-specific body fields such as
+  server-side MCP connector config can be merged into the request.
+
+### Changed
+
+- **Anthropic prompt caching adds a conversation-tail breakpoint.** With
+  `cache: true`, the last content block of the last message gets
+  `cache_control`, alongside existing system/tool breakpoints.
+- **Docs grouping updated.** `Alloy.Events` is grouped under Core,
+  `Alloy.Agent.Events` is left ungrouped as the deprecated shim, and
+  `Alloy.Memory` / `Alloy.Memory.Router` have a Memory group.
+
+### Docs
+
+- README documents non-goals, the compaction knobs and cache trade-off, strict
+  tools, Anthropic input examples/deferred loading, and OpenAI reasoning-item
+  persistence.
+- MCP recipe documents remote Anthropic MCP mounting via `mcp_servers`,
+  beta headers, and provider passthrough while keeping the client-side recipe
+  for local/stdio MCP.
 
 ## [0.12.3] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`:thinking` on `Alloy.Result`** (#36): a run result now surfaces the final
+  assistant reasoning text alongside `:text`, so callers no longer have to dig
+  it out of the last message's content blocks. Adds an `Alloy.Message.thinking/1`
+  helper for per-message extraction.
+
 ## [0.12.3] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Alloy is the completion-tool-call loop and nothing else. Send messages to any LLM, execute tool calls, loop until done. Swap providers with one line. No opinions on sessions, persistence, memory, scheduling, or UI — those belong in your application, where OTP already gives you the runtime.
 
-Alloy is [Pi](https://github.com/badlogic/pi-mono)'s philosophy brought to the BEAM: a harness, not a framework. Three runtime dependencies, ~7,500 lines — small enough to read in an afternoon, and everything beyond the loop is a [recipe](https://hexdocs.pm/alloy/sub-agents.html) built on the primitives, not a subsystem.
+Alloy is a harness, not a framework. Three runtime dependencies, ~7,500 lines — small enough to read in an afternoon, and everything beyond the loop is a [recipe](https://hexdocs.pm/alloy/sub-agents.html) built on the primitives, not a subsystem.
 
 ```elixir
 {:ok, result} = Alloy.run("Read mix.exs and tell me the version",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Alloy is the completion-tool-call loop and nothing else. Send messages to any LLM, execute tool calls, loop until done. Swap providers with one line. No opinions on sessions, persistence, memory, scheduling, or UI — those belong in your application, where OTP already gives you the runtime.
 
-Alloy is a harness, not a framework. Three runtime dependencies, ~7,500 lines — small enough to read in an afternoon, and everything beyond the loop is a [recipe](https://hexdocs.pm/alloy/sub-agents.html) built on the primitives, not a subsystem.
+Alloy is a harness, not a framework. Three runtime dependencies, ~9,000 lines — small enough to read in an afternoon, and everything beyond the loop is a [recipe](https://hexdocs.pm/alloy/sub-agents.html) built on the primitives, not a subsystem.
 
 ```elixir
 {:ok, result} = Alloy.run("Read mix.exs and tell me the version",
@@ -48,6 +48,15 @@ and could help any Alloy consumer, it likely belongs here. If it needs a
 database table, product defaults, UI decisions, or tenancy logic, it belongs in
 your application layer.
 
+## Non-goals
+
+Alloy does not own multi-agent orchestration; use the
+[sub-agents recipe](https://hexdocs.pm/alloy/sub-agents.html), where an agent
+spawns itself via a function call. Alloy does not sandbox your machine; use
+`:bash_executor` with containers or another isolated runner. Sessions,
+persistence, scheduling, hosted queues, dashboards, and UI stay in your
+application layer. The library stays small so those choices remain yours.
+
 ## What's in the box
 
 - **6 providers** — Anthropic, Gemini, OpenAI, Codex, xAI, and OpenAICompat (works with any OpenAI-compatible API: Ollama, OpenRouter, DeepSeek, Mistral, Groq, Together, etc.)
@@ -56,7 +65,7 @@ your application layer.
 - **Streaming** — token-by-token from any provider, unified interface
 - **Async dispatch** — `send_message/2` fires non-blocking, result arrives via PubSub
 - **Middleware** — custom hooks, tool blocking, argument editing
-- **Context compaction** — summary-based compaction when approaching token limits, with configurable reserve and fallback to truncation
+- **Context compaction** — tool-result clearing plus summary-based compaction when approaching token limits, with configurable reserve and fallback to truncation
 - **Memory primitive** — `Alloy.Memory` behaviour for Anthropic's `memory_20250818` tool. Alloy owns the wire format and path validation; you own the store (in-memory, disk, Postgres — whatever fits)
 - **Prompt caching** — Anthropic `cache: true` adds cache breakpoints for 60-90% input token savings
 - **Reasoning blocks** — DeepSeek/xAI `reasoning_content` parsed as first-class thinking blocks
@@ -66,7 +75,7 @@ your application layer.
 - **Telemetry** — run, turn, provider, and compaction lifecycle events for OTEL/logging/metrics
 - **Cost guard** — `max_budget_cents` halts the loop before overspending
 - **Pluggable model catalog** — `Alloy.ModelCatalog` behaviour; bring your own context-window source (e.g., an `llm_db` adapter)
-- **~7,500 lines** — small enough to read, understand, and extend
+- **~9,000 lines** — small enough to read, understand, and extend
 
 ## Installation
 
@@ -210,6 +219,13 @@ provider-native conversation:
   )
 ```
 
+For native OpenAI Responses, Alloy automatically preserves opaque reasoning
+items across stateless tool-call turns. When `store` is not `true` and no
+`previous_response_id` / `provider_state.response_id` is present, the request
+adds `include: ["reasoning.encrypted_content"]` and echoes returned reasoning
+items back verbatim before their related function calls; `result.text` ignores
+those opaque blocks.
+
 ### Provider-native tools and citations
 
 Responses-compatible providers can expose built-in server-side tools without
@@ -287,7 +303,7 @@ Resolution order: explicit `max_tokens` → `model_metadata_overrides` →
 fine — Alloy falls back to the default.
 
 Use `compaction:` when you want to tune how much room Alloy reserves before it
-summarizes older context:
+compacts older context:
 
 ```elixir
 {:ok, result} = Alloy.run("Summarise this repository",
@@ -295,10 +311,22 @@ summarizes older context:
   compaction: [
     reserve_tokens: 12_000,
     keep_recent_tokens: 8_000,
+    clear_tool_results: true,
+    keep_recent_tool_results: 3,
     fallback: :truncate
   ]
 )
 ```
+
+Alloy first clears old `tool_result` and `server_tool_result` content in one
+batch, preserving the newest `keep_recent_tool_results` results, then only
+calls the summarizer if the run is still over budget. Batched clearing matters
+with prompt caching: clearing invalidates cached prefixes, so Alloy amortizes
+that cost instead of dripping changes across turns.
+
+Set `summary_system_prompt:` and `summary_prompt:` inside `compaction:` when
+your application needs to own the handoff format. Both values must be strings;
+omitting them uses Alloy's default summary prompts.
 
 ### Cost guard
 
@@ -439,6 +467,7 @@ logging, or custom metrics:
   [:alloy, :turn, :start],
   [:alloy, :turn, :stop],
   [:alloy, :provider, :request],
+  [:alloy, :compaction, :cleared],
   [:alloy, :compaction, :done],
   [:alloy, :tool, :start],
   [:alloy, :tool, :stop],
@@ -453,6 +482,7 @@ logging, or custom metrics:
 | `[:alloy, :turn, :start]` | `system_time` | `turn` |
 | `[:alloy, :turn, :stop]` | — | `turn`, `status` |
 | `[:alloy, :provider, :request]` | `duration_ms` | `provider`, `model`, `streaming`, `attempt`, `result` |
+| `[:alloy, :compaction, :cleared]` | `results_cleared`, `bytes_cleared` | `turn` |
 | `[:alloy, :compaction, :done]` | `messages_before`, `messages_after` | `turn` |
 | `[:alloy, :tool, :start]` | — | tool identity, correlation |
 | `[:alloy, :tool, :stop]` | `duration_ms` | tool identity, result |
@@ -590,9 +620,13 @@ defmodule MyApp.Tools.WebSearch do
     %{
       type: "object",
       properties: %{query: %{type: "string", description: "Search query"}},
-      required: ["query"]
+      required: ["query"],
+      additionalProperties: false
     }
   end
+
+  @impl true
+  def strict?, do: true
 
   @impl true
   def execute(%{"query" => query}, _context) do
@@ -601,6 +635,17 @@ defmodule MyApp.Tools.WebSearch do
   end
 end
 ```
+
+Prefer strict mode for tools that have stable schemas. Set `strict?/0` on a
+module tool, or `strict: true` on an inline tool, and include
+`additionalProperties: false` in the top-level JSON Schema. Alloy validates
+that requirement instead of silently rewriting your schema. OpenAI strict mode
+also requires every property to be listed in `required`.
+
+For Anthropic advanced tool use, add `input_examples/0` or `input_examples:`
+with representative argument maps to improve parameter selection. Set
+`defer_loading?/0` or `defer_loading: true` for tools that should be exposed
+through Anthropic's deferred-loading path; other providers ignore these fields.
 
 ### Inline tools
 

--- a/docs/recipes/mcp-tools.md
+++ b/docs/recipes/mcp-tools.md
@@ -1,7 +1,6 @@
 # Recipe: MCP servers as tools
 
-Alloy has no MCP support in core, on purpose. The
-[context-economy argument](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/)
+Alloy has no MCP support in core, on purpose. The context-economy argument
 is real: a typical MCP server dumps every tool definition into every request —
 Playwright's server costs ~13,700 tokens of tool schemas before the
 conversation starts. Most Elixir applications also don't need MCP to expose
@@ -191,7 +190,7 @@ end
 **Gateway vs. one-tool-per-MCP-tool.** The gateway costs one tool definition
 and a compact name/description list — the right default, and the reason this
 recipe exists. The per-tool variant gives the model full schemas (provider-
-side argument validation) but pays the context cost Pi warns about: every
+side argument validation) but pays the context cost the gateway avoids: every
 tool's complete schema rides along on every request. Measure before choosing
 it for servers with more than a handful of tools, and consider filtering the
 discovery list to the tools you actually want exposed.

--- a/docs/recipes/mcp-tools.md
+++ b/docs/recipes/mcp-tools.md
@@ -129,6 +129,15 @@ Then just add it to `tools:`:
   )
 ```
 
+## Remote MCP without a client
+
+For remote HTTP MCP servers on Anthropic, you can also mount the server
+provider-side instead of running a client in your app. Pass Anthropic's
+`mcp_servers` body field and the matching beta header through `extra_body` /
+`extra_headers` on the provider config. The client-side gateway above remains
+the right pattern for local or stdio MCP servers and for providers without a
+server-side MCP connector.
+
 ## Variant: one tool per MCP tool
 
 When you want the model to see full per-tool schemas (better argument

--- a/docs/recipes/sub-agents.md
+++ b/docs/recipes/sub-agents.md
@@ -8,9 +8,9 @@ a supervised task, crashes are isolated to the tool call, and when the model
 requests several delegations in one turn the executor fans them out in
 parallel (`concurrent?/0`).
 
-This is the same philosophy as [Pi](https://github.com/badlogic/pi-mono),
-which spawns itself via bash rather than shipping a sub-agent system. Alloy's
-translation: spawn yourself via function call.
+This mirrors how the leanest coding agents handle delegation: they spawn
+another copy of themselves via a shell command rather than shipping a
+sub-agent subsystem. Alloy's translation: spawn yourself via function call.
 
 > The module below is tested verbatim in
 > `test/alloy/recipes/sub_agent_recipe_test.exs`. If the API drifts, that

--- a/lib/alloy/agent/config.ex
+++ b/lib/alloy/agent/config.ex
@@ -6,12 +6,17 @@ defmodule Alloy.Agent.Config do
   duration of the run.
   """
 
+  alias Alloy.Context.Compactor
   alias Alloy.ModelMetadata
 
   @type compaction :: %{
           reserve_tokens: pos_integer(),
           keep_recent_tokens: pos_integer(),
-          fallback: :truncate
+          fallback: :truncate,
+          clear_tool_results: boolean(),
+          keep_recent_tool_results: non_neg_integer(),
+          summary_system_prompt: String.t(),
+          summary_prompt: String.t()
         }
 
   @typedoc """
@@ -75,7 +80,15 @@ defmodule Alloy.Agent.Config do
     timeout_ms: 120_000,
     tool_timeout: 120_000,
     middleware: [],
-    compaction: %{reserve_tokens: 16_384, keep_recent_tokens: 20_000, fallback: :truncate},
+    compaction: %{
+      reserve_tokens: 16_384,
+      keep_recent_tokens: 20_000,
+      fallback: :truncate,
+      clear_tool_results: true,
+      keep_recent_tool_results: 3,
+      summary_system_prompt: Compactor.default_summary_system_prompt(),
+      summary_prompt: Compactor.default_summary_prompt()
+    },
     compaction_explicit: %{reserve_tokens: false, keep_recent_tokens: false},
     working_directory: ".",
     context: %{},
@@ -209,7 +222,11 @@ defmodule Alloy.Agent.Config do
             config.compaction_explicit.keep_recent_tokens,
             default_keep_recent_tokens(max_tokens)
           ),
-        fallback: config.compaction.fallback
+        fallback: config.compaction.fallback,
+        clear_tool_results: config.compaction.clear_tool_results,
+        keep_recent_tool_results: config.compaction.keep_recent_tool_results,
+        summary_system_prompt: config.compaction.summary_system_prompt,
+        summary_prompt: config.compaction.summary_prompt
       }
 
     %{
@@ -308,7 +325,26 @@ defmodule Alloy.Agent.Config do
           do: validate_compaction_tokens!(compaction.keep_recent_tokens, :keep_recent_tokens),
           else: default_keep_recent_tokens(max_tokens)
         ),
-      fallback: fallback
+      fallback: fallback,
+      clear_tool_results:
+        compaction
+        |> Map.get(:clear_tool_results, true)
+        |> validate_clear_tool_results!(),
+      keep_recent_tool_results:
+        compaction
+        |> Map.get(:keep_recent_tool_results, 3)
+        |> validate_keep_recent_tool_results!(),
+      summary_system_prompt:
+        compaction
+        |> Map.get(
+          :summary_system_prompt,
+          Compactor.default_summary_system_prompt()
+        )
+        |> validate_compaction_prompt!(:summary_system_prompt),
+      summary_prompt:
+        compaction
+        |> Map.get(:summary_prompt, Compactor.default_summary_prompt())
+        |> validate_compaction_prompt!(:summary_prompt)
     }
 
     {resolved, explicit}
@@ -347,6 +383,30 @@ defmodule Alloy.Agent.Config do
       {"fallback", value}, acc ->
         Map.put(acc, :fallback, value)
 
+      {:clear_tool_results, value}, acc ->
+        Map.put(acc, :clear_tool_results, value)
+
+      {"clear_tool_results", value}, acc ->
+        Map.put(acc, :clear_tool_results, value)
+
+      {:keep_recent_tool_results, value}, acc ->
+        Map.put(acc, :keep_recent_tool_results, value)
+
+      {"keep_recent_tool_results", value}, acc ->
+        Map.put(acc, :keep_recent_tool_results, value)
+
+      {:summary_system_prompt, value}, acc ->
+        Map.put(acc, :summary_system_prompt, value)
+
+      {"summary_system_prompt", value}, acc ->
+        Map.put(acc, :summary_system_prompt, value)
+
+      {:summary_prompt, value}, acc ->
+        Map.put(acc, :summary_prompt, value)
+
+      {"summary_prompt", value}, acc ->
+        Map.put(acc, :summary_prompt, value)
+
       {key, _value}, _acc ->
         raise ArgumentError, "unsupported compaction option: #{inspect(key)}"
     end)
@@ -360,6 +420,27 @@ defmodule Alloy.Agent.Config do
   defp validate_compaction_tokens!(value, field) do
     raise ArgumentError,
           "#{field} must be a positive integer, got: #{inspect(value)}"
+  end
+
+  defp validate_keep_recent_tool_results!(value) when is_integer(value) and value >= 0, do: value
+
+  defp validate_keep_recent_tool_results!(value) do
+    raise ArgumentError,
+          "keep_recent_tool_results must be a non-negative integer, got: #{inspect(value)}"
+  end
+
+  defp validate_clear_tool_results!(value) when is_boolean(value), do: value
+
+  defp validate_clear_tool_results!(value) do
+    raise ArgumentError,
+          "clear_tool_results must be a boolean, got: #{inspect(value)}"
+  end
+
+  defp validate_compaction_prompt!(value, _field) when is_binary(value), do: value
+
+  defp validate_compaction_prompt!(value, field) do
+    raise ArgumentError,
+          "#{field} must be a string, got: #{inspect(value)}"
   end
 
   defp validate_compaction_fallback(:truncate), do: :truncate

--- a/lib/alloy/agent/state.ex
+++ b/lib/alloy/agent/state.ex
@@ -183,6 +183,17 @@ defmodule Alloy.Agent.State do
   end
 
   @doc """
+  Extract the thinking/reasoning text from the most recent assistant message
+  that carries any. Returns `nil` when no assistant message has thinking.
+  """
+  @spec last_assistant_thinking(t()) :: String.t() | nil
+  def last_assistant_thinking(%__MODULE__{} = state) do
+    # Check the accumulator (newest messages) first, then fall back to base.
+    find_assistant_thinking(state.messages_new) ||
+      find_assistant_thinking_reversed(state.messages)
+  end
+
+  @doc """
   Clean up resources owned by this state. No-op currently; reserved
   for future resource management.
   """
@@ -203,6 +214,23 @@ defmodule Alloy.Agent.State do
     |> Enum.reverse()
     |> Enum.find_value(fn
       %Message{role: :assistant} = msg -> Message.text(msg)
+      _ -> nil
+    end)
+  end
+
+  # Thinking counterparts — same newest-first search, extracting thinking blocks.
+  defp find_assistant_thinking(messages_new) do
+    Enum.find_value(messages_new, fn
+      %Message{role: :assistant} = msg -> Message.thinking(msg)
+      _ -> nil
+    end)
+  end
+
+  defp find_assistant_thinking_reversed(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %Message{role: :assistant} = msg -> Message.thinking(msg)
       _ -> nil
     end)
   end

--- a/lib/alloy/agent/turn.ex
+++ b/lib/alloy/agent/turn.ex
@@ -94,7 +94,7 @@ defmodule Alloy.Agent.Turn do
     )
 
     messages_before = length(State.messages(state))
-    {compaction_status, state} = Compactor.maybe_compact(state)
+    {compaction_status, state} = Compactor.maybe_compact(state, turn: turn_number)
 
     state =
       case compaction_status do

--- a/lib/alloy/context/compactor.ex
+++ b/lib/alloy/context/compactor.ex
@@ -6,6 +6,16 @@ defmodule Alloy.Context.Compactor do
   preserves the first message, keeps a recent verbatim token window, and
   replaces older context with a structured handoff summary. If summary
   generation fails, Alloy falls back to deterministic truncation.
+
+  Compaction options live under `compaction:`:
+
+    * `:clear_tool_results` - clear old bulky tool-result content before
+      summary generation (default `true`)
+    * `:keep_recent_tool_results` - newest tool results to preserve verbatim
+      when clearing (default `3`)
+    * `:summary_system_prompt` - system prompt used for summary generation
+    * `:summary_prompt` - user prompt instructions appended after the
+      serialized conversation
   """
 
   require Logger
@@ -73,6 +83,14 @@ defmodule Alloy.Context.Compactor do
   - Keep the summary concise but decision-complete enough for the next model to continue without rereading the discarded messages.
   """
 
+  @doc false
+  @spec default_summary_system_prompt() :: String.t()
+  def default_summary_system_prompt, do: @summary_system_prompt
+
+  @doc false
+  @spec default_summary_prompt() :: String.t()
+  def default_summary_prompt, do: @summary_prompt
+
   @doc """
   Prefix used for synthetic handoff summary messages inserted by the compactor.
   """
@@ -94,15 +112,15 @@ defmodule Alloy.Context.Compactor do
   Returns `{:compacted, state}` when compaction occurred, or
   `{:unchanged, state}` when already within budget.
   """
-  @spec maybe_compact(State.t()) :: {:compacted | :unchanged, State.t()}
-  def maybe_compact(%State{} = state) do
+  @spec maybe_compact(State.t(), keyword()) :: {:compacted | :unchanged, State.t()}
+  def maybe_compact(%State{} = state, opts \\ []) do
     messages = State.messages(state)
     reserve_tokens = state.config.compaction.reserve_tokens
 
     if within_reserve?(messages, state.config.max_tokens, reserve_tokens) do
       {:unchanged, state}
     else
-      {:compacted, compact_messages_in_state(state, messages)}
+      {:compacted, compact_messages_in_state(state, messages, opts)}
     end
   end
 
@@ -116,7 +134,61 @@ defmodule Alloy.Context.Compactor do
     {first, middle, recent}
   end
 
-  defp compact_messages_in_state(%State{} = state, messages) do
+  defp compact_messages_in_state(%State{} = state, messages, opts \\ []) do
+    case maybe_clear_tool_results(messages, state, opts) do
+      {:done, cleared_messages} ->
+        %{state | messages: cleared_messages, messages_new: []}
+
+      {:continue, messages} ->
+        summarize_or_fallback(state, messages)
+    end
+  end
+
+  defp maybe_clear_tool_results(
+         messages,
+         %State{
+           turn: turn,
+           config: %{
+             max_tokens: max_tokens,
+             compaction:
+               %{
+                 clear_tool_results: true,
+                 keep_recent_tokens: keep_recent_tokens,
+                 reserve_tokens: reserve_tokens
+               } = compaction
+           }
+         },
+         opts
+       ) do
+    keep_recent_tool_results = Map.get(compaction, :keep_recent_tool_results, 3)
+    telemetry_turn = Keyword.get(opts, :turn, turn + 1)
+
+    {cleared_messages, cleared} =
+      clear_tool_results(messages,
+        keep_recent_tokens: keep_recent_tokens,
+        keep_recent_tool_results: keep_recent_tool_results
+      )
+
+    if cleared.results_cleared > 0 do
+      :telemetry.execute(
+        [:alloy, :compaction, :cleared],
+        cleared,
+        %{turn: telemetry_turn}
+      )
+
+      if within_reserve?(cleared_messages, max_tokens, reserve_tokens) do
+        {:done, cleared_messages}
+      else
+        {:continue, cleared_messages}
+      end
+    else
+      {:continue, messages}
+    end
+  end
+
+  defp maybe_clear_tool_results(messages, _state, _opts), do: {:continue, messages}
+
+  defp summarize_or_fallback(%State{} = state, messages) do
     keep_recent_tokens = state.config.compaction.keep_recent_tokens
 
     case prepare_summary_compaction(messages, keep_recent_tokens) do
@@ -140,6 +212,133 @@ defmodule Alloy.Context.Compactor do
         fallback_compact_state(state, messages)
     end
   end
+
+  defp clear_tool_results(messages, opts) do
+    keep_recent_tokens = Keyword.fetch!(opts, :keep_recent_tokens)
+    keep_recent_tool_results = Keyword.fetch!(opts, :keep_recent_tool_results)
+    old_indexes = MapSet.new(old_message_indexes(messages, keep_recent_tokens))
+
+    result_positions = tool_result_positions(messages)
+
+    keep_positions =
+      result_positions
+      |> Enum.take(-keep_recent_tool_results)
+      |> Enum.map(fn %{message_index: message_index, block_index: block_index} ->
+        {message_index, block_index}
+      end)
+      |> MapSet.new()
+
+    {cleared_messages, cleared} =
+      messages
+      |> Enum.with_index()
+      |> Enum.map_reduce(%{results_cleared: 0, bytes_cleared: 0}, fn {message, message_index},
+                                                                     acc ->
+        if MapSet.member?(old_indexes, message_index) do
+          clear_tool_results_in_message(message, message_index, keep_positions, acc)
+        else
+          {message, acc}
+        end
+      end)
+
+    {cleared_messages, cleared}
+  end
+
+  defp old_message_indexes([_first | rest] = _messages, keep_recent_tokens) do
+    {previous_summary, tail} =
+      case rest do
+        [%Message{} = message | rest_tail] ->
+          if summary_message?(message), do: {message, rest_tail}, else: {nil, rest}
+
+        [] ->
+          {nil, []}
+      end
+
+    offset = if previous_summary, do: 2, else: 1
+
+    if tail == [] do
+      []
+    else
+      cut_index = find_cut_point(tail, keep_recent_tokens)
+
+      if cut_index > 0 do
+        offset..(offset + cut_index - 1)//1 |> Enum.to_list()
+      else
+        []
+      end
+    end
+  end
+
+  defp old_message_indexes(_, _keep_recent_tokens), do: []
+
+  defp tool_result_positions(messages) do
+    messages
+    |> Enum.with_index()
+    |> Enum.flat_map(fn
+      {%Message{content: blocks}, message_index} when is_list(blocks) ->
+        blocks
+        |> Enum.with_index()
+        |> Enum.flat_map(fn
+          {%{type: type} = block, block_index}
+          when type in ["tool_result", "server_tool_result"] ->
+            [
+              %{
+                message_index: message_index,
+                block_index: block_index,
+                bytes: content_bytes(block)
+              }
+            ]
+
+          _ ->
+            []
+        end)
+
+      _ ->
+        []
+    end)
+  end
+
+  defp clear_tool_results_in_message(
+         %Message{content: blocks} = message,
+         message_index,
+         keep_positions,
+         acc
+       )
+       when is_list(blocks) do
+    {blocks, acc} =
+      blocks
+      |> Enum.with_index()
+      |> Enum.map_reduce(acc, fn
+        {%{type: type} = block, block_index}, acc
+        when type in ["tool_result", "server_tool_result"] ->
+          position = {message_index, block_index}
+
+          if MapSet.member?(keep_positions, position) do
+            {block, acc}
+          else
+            bytes = content_bytes(block)
+
+            {
+              %{block | content: "[tool result cleared: #{bytes} bytes]"},
+              %{
+                results_cleared: acc.results_cleared + 1,
+                bytes_cleared: acc.bytes_cleared + bytes
+              }
+            }
+          end
+
+        {block, _block_index}, acc ->
+          {block, acc}
+      end)
+
+    {%{message | content: blocks}, acc}
+  end
+
+  defp clear_tool_results_in_message(message, _message_index, _keep_positions, acc),
+    do: {message, acc}
+
+  defp content_bytes(%{content: content}) when is_binary(content), do: byte_size(content)
+  defp content_bytes(%{content: content}), do: content |> inspect() |> byte_size()
+  defp content_bytes(_block), do: 0
 
   defp fallback_compact_state(%State{} = state, messages) do
     case state.config.compaction.fallback do
@@ -190,9 +389,21 @@ defmodule Alloy.Context.Compactor do
       state.config.provider_config
       |> Map.delete(:provider_state)
       |> Map.delete("provider_state")
-      |> Map.put(:system_prompt, @summary_system_prompt)
+      |> Map.put(
+        :system_prompt,
+        Map.get(
+          state.config.compaction,
+          :summary_system_prompt,
+          default_summary_system_prompt()
+        )
+      )
 
-    prompt = build_summary_prompt(prepared.messages_to_summarize, prepared.previous_summary)
+    prompt =
+      build_summary_prompt(
+        prepared.messages_to_summarize,
+        prepared.previous_summary,
+        Map.get(state.config.compaction, :summary_prompt, default_summary_prompt())
+      )
 
     with {:ok, response} <- provider.complete([Message.user(prompt)], [], config),
          {:ok, summary_text} <- extract_summary_text(response) do
@@ -203,7 +414,7 @@ defmodule Alloy.Context.Compactor do
     end
   end
 
-  defp build_summary_prompt(messages_to_summarize, previous_summary) do
+  defp build_summary_prompt(messages_to_summarize, previous_summary, summary_prompt) do
     previous_summary_section =
       case previous_summary do
         nil ->
@@ -218,7 +429,7 @@ defmodule Alloy.Context.Compactor do
     #{serialize_messages(messages_to_summarize)}
     </conversation>
 
-    #{@summary_prompt}
+    #{summary_prompt}
     """
   end
 
@@ -433,12 +644,16 @@ defmodule Alloy.Context.Compactor do
         %{type: type} = block when type in ["tool_result", "server_tool_result"] ->
           %{block | content: "[compacted]"}
 
+        %{type: "thinking", signature: signature} when is_binary(signature) ->
+          nil
+
         %{type: "thinking", thinking: text} = block when byte_size(text) > @truncate_length ->
           %{block | thinking: String.slice(text, 0, @truncate_length) <> "..."}
 
         block ->
           block
       end)
+      |> Enum.reject(&is_nil/1)
 
     %{msg | content: compacted_blocks}
   end

--- a/lib/alloy/message.ex
+++ b/lib/alloy/message.ex
@@ -80,6 +80,22 @@ defmodule Alloy.Message do
   end
 
   @doc """
+  Extracts thinking/reasoning text from a message, joining all thinking blocks.
+
+  Returns `nil` when the message carries no thinking content (plain-text
+  messages and messages without `"thinking"` blocks).
+  """
+  @spec thinking(t()) :: String.t() | nil
+  def thinking(%__MODULE__{content: content}) when is_binary(content), do: nil
+
+  def thinking(%__MODULE__{content: blocks}) when is_list(blocks) do
+    case Enum.filter(blocks, &(is_map(&1) && &1[:type] == "thinking")) do
+      [] -> nil
+      thinking_blocks -> Enum.map_join(thinking_blocks, "\n", & &1[:thinking])
+    end
+  end
+
+  @doc """
   Extracts tool_use blocks from an assistant message.
   """
   @spec tool_calls(t()) :: [content_block()]

--- a/lib/alloy/provider/anthropic.ex
+++ b/lib/alloy/provider/anthropic.ex
@@ -18,6 +18,7 @@ defmodule Alloy.Provider.Anthropic do
   - `:api_url` - Base URL (default: "https://api.anthropic.com")
   - `:api_version` - API version header (default: "2023-06-01")
   - `:extra_headers` - Additional headers as `[{name, value}]`
+  - `:extra_body` - Additional request body fields, merged last
   - `:req_options` - Additional options passed to Req (useful for testing)
   - `:extended_thinking` - Enable extended thinking. Pass a keyword list with
     `:budget_tokens` (e.g., `[budget_tokens: 5000]`). Thinking blocks are
@@ -54,6 +55,7 @@ defmodule Alloy.Provider.Anthropic do
   @code_execution_beta "code-execution-2025-08-25"
   @memory_tool_type "memory_20250818"
   @memory_beta "context-management-2025-06-27"
+  @advanced_tool_use_beta "advanced-tool-use-2025-11-20"
 
   @typedoc """
   Configuration for the Anthropic provider. See the module doc for field
@@ -67,6 +69,7 @@ defmodule Alloy.Provider.Anthropic do
           optional(:api_url) => String.t(),
           optional(:api_version) => String.t(),
           optional(:extra_headers) => [{String.t(), String.t()}],
+          optional(:extra_body) => map(),
           optional(:req_options) => keyword(),
           optional(:extended_thinking) => keyword(),
           optional(:on_event) => (term() -> :ok),
@@ -84,7 +87,7 @@ defmodule Alloy.Provider.Anthropic do
       ([
          url: "#{Map.get(config, :api_url, @default_api_url)}/v1/messages",
          method: :post,
-         headers: build_headers(config),
+         headers: build_headers(config, tool_defs),
          body: Jason.encode!(body)
        ] ++ Map.get(config, :req_options, []))
       |> Keyword.put(:retry, false)
@@ -134,7 +137,7 @@ defmodule Alloy.Provider.Anthropic do
       ([
          url: "#{Map.get(config, :api_url, @default_api_url)}/v1/messages",
          method: :post,
-         headers: build_headers(config),
+         headers: build_headers(config, tool_defs),
          body: Jason.encode!(body),
          into: stream_handler
        ] ++ Map.get(config, :req_options, []))
@@ -297,6 +300,7 @@ defmodule Alloy.Provider.Anthropic do
     }
 
     cache? = Map.get(config, :cache, false)
+    body = maybe_add_cache_to_conversation_tail(body, cache?)
 
     body =
       case Map.get(config, :system_prompt) do
@@ -332,25 +336,37 @@ defmodule Alloy.Provider.Anthropic do
       |> maybe_add_code_execution(config)
       |> maybe_add_memory_tool(config)
 
-    case Map.get(config, :extended_thinking) do
-      nil ->
-        body
+    body =
+      case Map.get(config, :extended_thinking) do
+        nil ->
+          body
 
-      opts when is_list(opts) ->
-        budget = Keyword.get(opts, :budget_tokens)
+        opts when is_list(opts) ->
+          budget = Keyword.get(opts, :budget_tokens)
 
-        unless is_integer(budget) and budget > 0 do
-          raise ArgumentError,
-                "extended_thinking requires a positive integer :budget_tokens, got: #{inspect(budget)}"
-        end
+          unless is_integer(budget) and budget > 0 do
+            raise ArgumentError,
+                  "extended_thinking requires a positive integer :budget_tokens, got: #{inspect(budget)}"
+          end
 
-        Map.put(body, "thinking", %{"type" => "enabled", "budget_tokens" => budget})
+          Map.put(body, "thinking", %{"type" => "enabled", "budget_tokens" => budget})
 
-      _opts ->
-        # Non-list value (e.g., extended_thinking: true) — silently ignore
-        body
-    end
+        _opts ->
+          # Non-list value (e.g., extended_thinking: true) — silently ignore
+          body
+      end
+
+    Map.merge(body, stringify_extra_body(Map.get(config, :extra_body, %{})))
   end
+
+  defp stringify_extra_body(extra_body) when is_map(extra_body) do
+    Map.new(extra_body, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  defp stringify_extra_body(_), do: %{}
 
   defp maybe_add_code_execution(body, config) do
     if Map.get(config, :code_execution, false) do
@@ -378,7 +394,7 @@ defmodule Alloy.Provider.Anthropic do
     end
   end
 
-  defp build_headers(config) do
+  defp build_headers(config, tool_defs) do
     extra_headers = Map.get(config, :extra_headers, [])
     {beta_values, other_headers} = split_anthropic_beta_headers(extra_headers)
 
@@ -395,11 +411,25 @@ defmodule Alloy.Provider.Anthropic do
         {_module, _store} -> [@memory_beta | beta_values]
       end
 
+    beta_values =
+      if advanced_tool_use?(tool_defs) do
+        [@advanced_tool_use_beta | beta_values]
+      else
+        beta_values
+      end
+
     [
       {"x-api-key", config.api_key},
       {"anthropic-version", Map.get(config, :api_version, @default_api_version)},
       {"content-type", "application/json"}
     ] ++ build_beta_headers(beta_values) ++ other_headers
+  end
+
+  defp advanced_tool_use?(tool_defs) do
+    Enum.any?(tool_defs, fn tool_def ->
+      Map.get(tool_def, :defer_loading) == true or
+        match?([_ | _], Map.get(tool_def, :input_examples))
+    end)
   end
 
   defp split_anthropic_beta_headers(headers) do
@@ -423,6 +453,53 @@ defmodule Alloy.Provider.Anthropic do
 
     [{"anthropic-beta", merged_value}]
   end
+
+  defp maybe_add_cache_to_conversation_tail(body, false), do: body
+
+  defp maybe_add_cache_to_conversation_tail(%{"messages" => []} = body, true), do: body
+
+  defp maybe_add_cache_to_conversation_tail(%{"messages" => messages} = body, true) do
+    {init, [last]} = Enum.split(messages, -1)
+    Map.put(body, "messages", init ++ [add_cache_to_message_tail(last)])
+  end
+
+  defp add_cache_to_message_tail(%{"content" => content} = message) when is_binary(content) do
+    Map.put(message, "content", [
+      %{"type" => "text", "text" => content, "cache_control" => %{"type" => "ephemeral"}}
+    ])
+  end
+
+  defp add_cache_to_message_tail(%{"content" => blocks} = message)
+       when is_list(blocks) and blocks != [] do
+    Map.put(message, "content", add_cache_to_last_cacheable_block(blocks))
+  end
+
+  defp add_cache_to_message_tail(message), do: message
+
+  defp add_cache_to_last_cacheable_block(blocks) do
+    {blocks, _added?} =
+      blocks
+      |> Enum.reverse()
+      |> Enum.map_reduce(false, fn
+        block, false ->
+          if cacheable_message_block?(block) do
+            {Map.put(block, "cache_control", %{"type" => "ephemeral"}), true}
+          else
+            {block, false}
+          end
+
+        block, true ->
+          {block, true}
+      end)
+
+    Enum.reverse(blocks)
+  end
+
+  defp cacheable_message_block?(%{"type" => type}) when type in ["thinking", "redacted_thinking"],
+    do: false
+
+  defp cacheable_message_block?(block) when is_map(block), do: true
+  defp cacheable_message_block?(_block), do: false
 
   defp format_message(%Message{role: role, content: content}) when is_binary(content) do
     %{"role" => to_string(role), "content" => content}
@@ -506,17 +583,36 @@ defmodule Alloy.Provider.Anthropic do
   end
 
   defp format_tool_def(%{name: name, description: desc, input_schema: schema} = def_map) do
-    base = %{
-      "name" => name,
-      "description" => desc,
-      "input_schema" => Alloy.Provider.stringify_keys(schema)
-    }
+    base =
+      %{
+        "name" => name,
+        "description" => desc,
+        "input_schema" => Alloy.Provider.stringify_keys(schema)
+      }
+      |> maybe_put_strict(def_map)
+      |> maybe_put_input_examples(def_map)
+      |> maybe_put_defer_loading(def_map)
 
     case Map.get(def_map, :allowed_callers) do
       nil -> base
       callers -> Map.put(base, "allowed_callers", Enum.map(callers, &to_string/1))
     end
   end
+
+  defp maybe_put_strict(tool, %{strict: true}), do: Map.put(tool, "strict", true)
+  defp maybe_put_strict(tool, _def_map), do: tool
+
+  defp maybe_put_input_examples(tool, %{input_examples: examples}) when is_list(examples) do
+    Map.put(tool, "input_examples", examples)
+  end
+
+  defp maybe_put_input_examples(tool, _def_map), do: tool
+
+  defp maybe_put_defer_loading(tool, %{defer_loading: true}) do
+    Map.put(tool, "defer_loading", true)
+  end
+
+  defp maybe_put_defer_loading(tool, _def_map), do: tool
 
   # --- Response Parsing ---
 

--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -23,6 +23,8 @@ defmodule Alloy.Provider.Codex do
     (default: `System.tmp_dir!/0`)
   - `:timeout_ms` - Timeout for a single `codex exec` invocation
     (default: `120_000`)
+  - `:receive_timeout` - Optional turn deadline timeout injected by Alloy's
+    retry loop; when present it caps `:timeout_ms`
   - `:command_runner` - Test hook matching `System.cmd/3`
   - `:system_prompt` - System prompt string
 
@@ -90,6 +92,7 @@ defmodule Alloy.Provider.Codex do
           optional(:auth_path) => String.t(),
           optional(:tmp_dir) => String.t(),
           optional(:timeout_ms) => pos_integer(),
+          optional(:receive_timeout) => pos_integer(),
           optional(:system_prompt) => String.t(),
           optional(:command_runner) => (String.t(), [String.t()], keyword() ->
                                           {String.t(), integer()})
@@ -191,7 +194,7 @@ defmodule Alloy.Provider.Codex do
 
   defp run_codex(prompt, paths, config) do
     executable = Map.get(config, :codex_bin, @default_codex_bin)
-    timeout = Map.get(config, :timeout_ms, @default_timeout_ms)
+    timeout = effective_timeout(config)
 
     args =
       [
@@ -213,6 +216,18 @@ defmodule Alloy.Provider.Codex do
       run_injected(config, executable, args, paths)
     else
       run_port(executable, args, paths, timeout)
+    end
+  end
+
+  defp effective_timeout(config) do
+    timeout_ms = Map.get(config, :timeout_ms, @default_timeout_ms)
+
+    case Map.get(config, :receive_timeout) do
+      receive_timeout when is_integer(receive_timeout) and receive_timeout > 0 ->
+        min(receive_timeout, timeout_ms)
+
+      _ ->
+        timeout_ms
     end
   end
 

--- a/lib/alloy/provider/openai.ex
+++ b/lib/alloy/provider/openai.ex
@@ -30,6 +30,10 @@ defmodule Alloy.Provider.OpenAI do
   - `:x_search` - `true` or a config map to append an `x_search` tool
   - `:req_options` - Additional options passed to Req
 
+  In stateless mode (`store` not `true` with no previous response ID), Alloy
+  automatically requests encrypted reasoning content and round-trips opaque
+  reasoning output items between tool calls.
+
   ## Example
 
       Alloy.run("Summarize this code.",
@@ -172,6 +176,7 @@ defmodule Alloy.Provider.OpenAI do
       |> maybe_put_previous_response_id(config)
       |> maybe_put_optional_request_field("store", Map.get(config, :store))
       |> maybe_put_optional_request_field("include", Map.get(config, :include))
+      |> maybe_put_reasoning_include(config)
       |> maybe_put_optional_request_field("tool_choice", Map.get(config, :tool_choice))
       |> maybe_put_optional_request_field(
         "parallel_tool_calls",
@@ -201,16 +206,30 @@ defmodule Alloy.Provider.OpenAI do
   defp stringify_extra_body(_), do: %{}
 
   defp maybe_put_previous_response_id(body, config) do
-    previous_response_id =
-      Map.get(config, :previous_response_id) ||
-        get_in(config, [:provider_state, :response_id])
+    maybe_put_optional_request_field(body, "previous_response_id", previous_response_id(config))
+  end
 
-    maybe_put_optional_request_field(body, "previous_response_id", previous_response_id)
+  defp previous_response_id(config) do
+    Map.get(config, :previous_response_id) ||
+      get_in(config, [:provider_state, :response_id])
   end
 
   defp maybe_put_optional_request_field(body, _key, nil), do: body
   defp maybe_put_optional_request_field(body, _key, value) when value == [], do: body
   defp maybe_put_optional_request_field(body, key, value), do: Map.put(body, key, value)
+
+  defp maybe_put_reasoning_include(body, config) do
+    if stateless_reasoning_echo?(config) do
+      put_reasoning_include(body)
+    else
+      body
+    end
+  end
+
+  defp put_reasoning_include(body) do
+    includes = body |> Map.get("include", []) |> List.wrap()
+    Map.put(body, "include", Enum.uniq(includes ++ ["reasoning.encrypted_content"]))
+  end
 
   defp built_in_tools(config) do
     []
@@ -254,39 +273,32 @@ defmodule Alloy.Provider.OpenAI do
         prompt -> [%{"role" => "system", "content" => prompt}]
       end
 
-    convo_items = Enum.flat_map(messages, &format_input_item/1)
+    stateless? = stateless_reasoning_echo?(config)
+    convo_items = Enum.flat_map(messages, &format_input_item(&1, stateless?))
     system_items ++ convo_items
   end
 
-  defp format_input_item(%Message{role: :user, content: content}) when is_binary(content) do
+  defp stateless_reasoning_echo?(config) do
+    Map.get(config, :store) != true and is_nil(previous_response_id(config))
+  end
+
+  defp format_input_item(%Message{role: :user, content: content}, _stateless?)
+       when is_binary(content) do
     [%{"role" => "user", "content" => content}]
   end
 
-  defp format_input_item(%Message{role: :assistant, content: content}) when is_binary(content) do
+  defp format_input_item(%Message{role: :assistant, content: content}, _stateless?)
+       when is_binary(content) do
     [%{"role" => "assistant", "content" => content}]
   end
 
-  defp format_input_item(%Message{role: :assistant, content: blocks}) when is_list(blocks) do
-    function_calls =
-      blocks
-      |> Enum.filter(&(&1[:type] == "tool_use"))
-      |> Enum.map(&format_assistant_function_call_item/1)
-
-    text_parts =
-      blocks
-      |> Enum.filter(&(&1[:type] == "text"))
-      |> Enum.map_join("\n", & &1.text)
-
-    assistant_text_item =
-      case text_parts do
-        "" -> []
-        text -> [%{"role" => "assistant", "content" => text}]
-      end
-
-    assistant_text_item ++ function_calls
+  defp format_input_item(%Message{role: :assistant, content: blocks}, stateless?)
+       when is_list(blocks) do
+    Enum.flat_map(blocks, &format_assistant_block(&1, stateless?))
   end
 
-  defp format_input_item(%Message{role: :user, content: blocks}) when is_list(blocks) do
+  defp format_input_item(%Message{role: :user, content: blocks}, _stateless?)
+       when is_list(blocks) do
     if Enum.any?(blocks, &(&1[:type] == "tool_result")) do
       blocks
       |> Enum.map(fn
@@ -329,6 +341,21 @@ defmodule Alloy.Provider.OpenAI do
 
   defp format_user_content_block(_block), do: nil
 
+  defp format_assistant_block(%{type: "text", text: text}, _stateless?)
+       when is_binary(text) and text != "" do
+    [%{"role" => "assistant", "content" => text}]
+  end
+
+  defp format_assistant_block(%{type: "tool_use"} = block, _stateless?) do
+    [format_assistant_function_call_item(block)]
+  end
+
+  defp format_assistant_block(%{type: "reasoning", raw: raw}, true) when is_map(raw) do
+    [raw]
+  end
+
+  defp format_assistant_block(_block, _stateless?), do: []
+
   defp unsupported_media_notice(mime_type) do
     %{
       "type" => "input_text",
@@ -336,13 +363,15 @@ defmodule Alloy.Provider.OpenAI do
     }
   end
 
-  defp format_tool_def(%{name: name, description: desc, input_schema: schema}) do
-    %{
+  defp format_tool_def(%{name: name, description: desc, input_schema: schema} = def_map) do
+    tool = %{
       "type" => "function",
       "name" => name,
       "description" => desc,
       "parameters" => Alloy.Provider.stringify_keys(schema)
     }
+
+    if Map.get(def_map, :strict) == true, do: Map.put(tool, "strict", true), else: tool
   end
 
   defp format_assistant_function_call_item(%{id: id, name: name, input: input}) do
@@ -537,6 +566,10 @@ defmodule Alloy.Provider.OpenAI do
       {:error, _} = err ->
         err
     end
+  end
+
+  defp parse_output_item(%{"type" => "reasoning"} = item) do
+    {:ok, [%{type: "reasoning", raw: item}]}
   end
 
   defp parse_output_item(_item), do: {:ok, []}

--- a/lib/alloy/provider/openai_compat.ex
+++ b/lib/alloy/provider/openai_compat.ex
@@ -242,15 +242,19 @@ defmodule Alloy.Provider.OpenAICompat do
 
   defp format_user_content_block(_), do: nil
 
-  defp format_tool_def(%{name: name, description: desc, input_schema: schema}) do
-    %{
-      "type" => "function",
-      "function" => %{
-        "name" => name,
-        "description" => desc,
-        "parameters" => Alloy.Provider.stringify_keys(schema)
-      }
+  defp format_tool_def(%{name: name, description: desc, input_schema: schema} = def_map) do
+    function = %{
+      "name" => name,
+      "description" => desc,
+      "parameters" => Alloy.Provider.stringify_keys(schema)
     }
+
+    function =
+      if Map.get(def_map, :strict) == true,
+        do: Map.put(function, "strict", true),
+        else: function
+
+    %{"type" => "function", "function" => function}
   end
 
   # --- Response Parsing ---

--- a/lib/alloy/result.ex
+++ b/lib/alloy/result.ex
@@ -8,6 +8,8 @@ defmodule Alloy.Result do
   ## Fields
 
     * `:text` — the final assistant text (or `nil` if the model returned no text)
+    * `:thinking` — the final assistant thinking/reasoning text (or `nil` if none),
+      so callers need not dig it out of the last message's content blocks
     * `:messages` — full conversation history
     * `:usage` — accumulated `%Alloy.Usage{}` token counts
     * `:tool_calls` — list of tool execution metadata maps
@@ -25,6 +27,7 @@ defmodule Alloy.Result do
 
   @type t :: %__MODULE__{
           text: String.t() | nil,
+          thinking: String.t() | nil,
           messages: [Message.t()],
           usage: Usage.t(),
           tool_calls: [map()],
@@ -37,6 +40,7 @@ defmodule Alloy.Result do
 
   defstruct [
     :text,
+    :thinking,
     :error,
     :request_id,
     messages: [],
@@ -58,6 +62,7 @@ defmodule Alloy.Result do
   def from_state(%State{} = state) do
     %__MODULE__{
       text: State.last_assistant_text(state),
+      thinking: State.last_assistant_thinking(state),
       messages: State.messages(state),
       usage: state.usage,
       tool_calls: state.tool_calls,

--- a/lib/alloy/testing.ex
+++ b/lib/alloy/testing.ex
@@ -54,7 +54,7 @@ defmodule Alloy.Testing do
 
   ## Options
 
-  - `:tools` - list of tool modules or inline tools (default: `[Alloy.Test.EchoTool]`)
+  - `:tools` - list of tool modules or inline tools (default: an inline `echo` tool)
   - `:system_prompt` - system prompt string
   - `:max_turns` - maximum turns (default: 10)
   - `:middleware` - list of middleware modules
@@ -68,7 +68,7 @@ defmodule Alloy.Testing do
     config = %Config{
       provider: TestProvider,
       provider_config: %{agent_pid: pid},
-      tools: Keyword.get(opts, :tools, [Alloy.Test.EchoTool]),
+      tools: Keyword.get(opts, :tools, default_tools()),
       system_prompt: Keyword.get(opts, :system_prompt),
       max_turns: Keyword.get(opts, :max_turns, 10),
       middleware: Keyword.get(opts, :middleware, []),
@@ -110,6 +110,26 @@ defmodule Alloy.Testing do
   """
   @spec error_response(term()) :: {:error, term()}
   def error_response(reason), do: TestProvider.error_response(reason)
+
+  @doc false
+  @spec default_tools() :: [Alloy.Tool.Inline.t()]
+  def default_tools do
+    [
+      Alloy.Tool.inline(
+        name: "echo",
+        description: "Echoes input back",
+        input_schema: %{
+          type: "object",
+          properties: %{text: %{type: "string"}},
+          required: ["text"]
+        },
+        execute: fn
+          %{"text" => text}, _context -> {:ok, "Echo: #{text}"}
+          %{text: text}, _context -> {:ok, "Echo: #{text}"}
+        end
+      )
+    ]
+  end
 
   @doc """
   Extract the text content from the last assistant message in a result.

--- a/lib/alloy/tool.ex
+++ b/lib/alloy/tool.ex
@@ -15,6 +15,12 @@ defmodule Alloy.Tool do
     (`:human`, `:code_execution`). Defaults to `[:human]`.
   - `result_type/0` — declares whether the tool returns `:text` or
     `:structured` data. Defaults to `:text`.
+  - `strict?/0` — requests provider strict-mode schema enforcement. Defaults
+    to `false`.
+  - `input_examples/0` — example inputs for providers that support advanced
+    tool-use metadata. Defaults to `[]`.
+  - `defer_loading?/0` — requests provider-side deferred loading where
+    supported. Defaults to `false`.
 
   ## Structured Results
 
@@ -116,6 +122,24 @@ defmodule Alloy.Tool do
   @callback result_type() :: :text | :structured
 
   @doc """
+  Whether providers should use strict schema enforcement for this tool.
+
+  Strict tools must declare `additionalProperties: false` on their top-level
+  input schema. Alloy validates this instead of mutating the schema silently.
+  """
+  @callback strict?() :: boolean()
+
+  @doc """
+  Example tool inputs for provider tool-use guidance.
+  """
+  @callback input_examples() :: [map()]
+
+  @doc """
+  Whether providers that support deferred tool loading should defer this tool.
+  """
+  @callback defer_loading?() :: boolean()
+
+  @doc """
   Maximum characters in the tool result before truncation.
   The executor truncates results exceeding this, keeping head + tail.
   Defaults to `:unlimited` when not implemented.
@@ -129,7 +153,15 @@ defmodule Alloy.Tool do
   """
   @callback concurrent?() :: boolean()
 
-  @optional_callbacks [allowed_callers: 0, result_type: 0, max_result_chars: 0, concurrent?: 0]
+  @optional_callbacks [
+    allowed_callers: 0,
+    result_type: 0,
+    strict?: 0,
+    input_examples: 0,
+    defer_loading?: 0,
+    max_result_chars: 0,
+    concurrent?: 0
+  ]
 
   @doc """
   Build an inline tool — a tool defined as data instead of a module.

--- a/lib/alloy/tool/executor.ex
+++ b/lib/alloy/tool/executor.ex
@@ -66,7 +66,7 @@ defmodule Alloy.Tool.Executor do
                 pair
 
               {{:exit, reason}, tag} ->
-                crashed(call_from(tag), reason, on_event, seq_ref, corr_id, turn)
+                crashed(call_from(tag), reason, tool_timeout, on_event, seq_ref, corr_id, turn)
             end)
           end
 
@@ -117,13 +117,14 @@ defmodule Alloy.Tool.Executor do
           rescue
             e ->
               stacktrace = __STACKTRACE__
-              err = "Tool crashed: #{Exception.message(e)}"
+              visible_error = tool_crash_message(call[:name], e, stacktrace)
+              diagnostic_error = Exception.format(:error, e, stacktrace)
 
-              Logger.warning(
+              Logger.error(
                 "Tool #{call[:name]} crashed: #{Exception.message(e)}\n#{Exception.format_stacktrace(stacktrace)}"
               )
 
-              {block_fn.(call[:id], err, true), err, nil}
+              {block_fn.(call[:id], visible_error, true), diagnostic_error, nil}
           end
 
         :error ->
@@ -170,8 +171,17 @@ defmodule Alloy.Tool.Executor do
      Map.merge(meta, %{correlation_id: corr_id, start_event_seq: sseq, end_event_seq: eseq})}
   end
 
-  defp crashed(call, reason, on_event, seq_ref, corr_id, turn) do
-    error = "Tool execution crashed: #{inspect(reason)}"
+  defp crashed(call, reason, tool_timeout, on_event, seq_ref, corr_id, turn) do
+    error =
+      case reason do
+        :timeout ->
+          "Tool #{call[:name]} timed out after #{tool_timeout}ms. " <>
+            "Try a smaller input or raise :tool_timeout."
+
+        _ ->
+          "Tool #{call[:name]} crashed during execution: #{inspect(reason)}. " <>
+            "Check the input and try again."
+      end
 
     meta = %{
       id: call[:id],
@@ -189,6 +199,24 @@ defmodule Alloy.Tool.Executor do
 
   defp call_from({:execute, c}), do: c
   defp call_from({:blocked, c, _}), do: c
+
+  defp tool_crash_message(tool_name, exception, stacktrace) do
+    "Tool #{tool_name} crashed: #{Exception.message(exception)} " <>
+      "(#{format_top_stack_frame(stacktrace)}). Check the input and try again."
+  end
+
+  defp format_top_stack_frame([{module, function, arity_or_args, info} | _]) do
+    arity = stack_arity(arity_or_args)
+    file = info |> Keyword.get(:file, "unknown") |> to_string() |> Path.basename()
+    line = Keyword.get(info, :line, "?")
+
+    "#{inspect(module)}.#{function}/#{arity} at #{file}:#{line}"
+  end
+
+  defp format_top_stack_frame(_stacktrace), do: "unknown location"
+
+  defp stack_arity(arity) when is_integer(arity), do: arity
+  defp stack_arity(args) when is_list(args), do: length(args)
 
   defp emit_start(on_event, call, seq_ref, corr_id, turn) do
     seq = :atomics.add_get(seq_ref, 1, 1)

--- a/lib/alloy/tool/inline.ex
+++ b/lib/alloy/tool/inline.ex
@@ -51,6 +51,12 @@ defmodule Alloy.Tool.Inline do
     (default `nil`, omitted from the tool definition)
   - `:result_type` - as `c:Alloy.Tool.result_type/0`
     (default `nil`, omitted from the tool definition)
+  - `:strict` - request provider strict-mode schema enforcement
+    (default `false`)
+  - `:input_examples` - example input maps for providers that support them
+    (default `[]`)
+  - `:defer_loading` - request provider-side deferred tool loading
+    (default `false`)
   """
 
   @enforce_keys [:name, :description, :input_schema, :execute]
@@ -62,6 +68,9 @@ defmodule Alloy.Tool.Inline do
     :max_result_chars,
     :allowed_callers,
     :result_type,
+    input_examples: [],
+    strict: false,
+    defer_loading: false,
     concurrent?: true
   ]
 
@@ -76,7 +85,10 @@ defmodule Alloy.Tool.Inline do
           concurrent?: boolean(),
           max_result_chars: pos_integer() | :unlimited | nil,
           allowed_callers: [atom()] | nil,
-          result_type: :text | :structured | nil
+          result_type: :text | :structured | nil,
+          input_examples: [map()],
+          strict: boolean(),
+          defer_loading: boolean()
         }
 
   @doc false
@@ -103,6 +115,24 @@ defmodule Alloy.Tool.Inline do
       raise ArgumentError,
             "inline tool #{inspect(tool.name)} :execute must be a 2-arity function " <>
               "(input, context). Got: #{inspect(tool.execute)}"
+    end
+
+    unless is_boolean(tool.strict) do
+      raise ArgumentError,
+            "inline tool #{inspect(tool.name)} :strict must be a boolean. " <>
+              "Got: #{inspect(tool.strict)}"
+    end
+
+    unless is_list(tool.input_examples) and Enum.all?(tool.input_examples, &is_map/1) do
+      raise ArgumentError,
+            "inline tool #{inspect(tool.name)} :input_examples must be a list of maps. " <>
+              "Got: #{inspect(tool.input_examples)}"
+    end
+
+    unless is_boolean(tool.defer_loading) do
+      raise ArgumentError,
+            "inline tool #{inspect(tool.name)} :defer_loading must be a boolean. " <>
+              "Got: #{inspect(tool.defer_loading)}"
     end
 
     tool

--- a/lib/alloy/tool/registry.ex
+++ b/lib/alloy/tool/registry.ex
@@ -41,33 +41,97 @@ defmodule Alloy.Tool.Registry do
   defp tool_name(mod), do: mod.name()
 
   defp tool_def(%Inline{} = tool) do
-    %{
+    def_map = %{
       name: tool.name,
       description: tool.description,
       input_schema: tool.input_schema
     }
+
+    validate_strict_schema!(def_map, tool.strict)
+
+    def_map
     |> maybe_put(:allowed_callers, tool.allowed_callers)
     |> maybe_put(:result_type, tool.result_type)
+    |> maybe_put_strict(tool.strict)
+    |> maybe_put_non_empty(:input_examples, tool.input_examples)
+    |> maybe_put_true(:defer_loading, tool.defer_loading)
   end
 
   defp tool_def(mod) do
-    %{
+    def_map = %{
       name: mod.name(),
       description: mod.description(),
       input_schema: mod.input_schema()
     }
+
+    strict = optional_callback(mod, :strict?, 0, false)
+    validate_strict_schema!(def_map, strict)
+
+    def_map
     |> maybe_put_optional(mod, :allowed_callers, 0)
     |> maybe_put_optional(mod, :result_type, 0)
+    |> maybe_put_strict(strict)
+    |> maybe_put_optional_non_empty(mod, :input_examples, 0)
+    |> maybe_put_optional_true(mod, :defer_loading?, 0, :defer_loading)
   end
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_put_strict(map, true), do: Map.put(map, :strict, true)
+  defp maybe_put_strict(map, _strict), do: map
+
+  defp maybe_put_non_empty(map, _key, nil), do: map
+  defp maybe_put_non_empty(map, _key, []), do: map
+  defp maybe_put_non_empty(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_put_true(map, key, true), do: Map.put(map, key, true)
+  defp maybe_put_true(map, _key, _value), do: map
 
   defp maybe_put_optional(map, mod, callback, arity) do
     if function_exported?(mod, callback, arity) do
       Map.put(map, callback, apply(mod, callback, []))
     else
       map
+    end
+  end
+
+  defp optional_callback(mod, callback, arity, default) do
+    if function_exported?(mod, callback, arity) do
+      apply(mod, callback, [])
+    else
+      default
+    end
+  end
+
+  defp maybe_put_optional_non_empty(map, mod, callback, arity) do
+    if function_exported?(mod, callback, arity) do
+      maybe_put_non_empty(map, callback, apply(mod, callback, []))
+    else
+      map
+    end
+  end
+
+  defp maybe_put_optional_true(map, mod, callback, arity, key) do
+    if function_exported?(mod, callback, arity) do
+      maybe_put_true(map, key, apply(mod, callback, []))
+    else
+      map
+    end
+  end
+
+  defp validate_strict_schema!(_def_map, false), do: :ok
+  defp validate_strict_schema!(_def_map, nil), do: :ok
+
+  defp validate_strict_schema!(%{name: name, input_schema: schema}, true) do
+    if Map.get(schema, :additionalProperties) == false or
+         Map.get(schema, "additionalProperties") == false do
+      :ok
+    else
+      raise ArgumentError,
+            "strict tool #{inspect(name)} input_schema must include " <>
+              "additionalProperties: false. OpenAI strict mode also requires every " <>
+              "property to be listed in required."
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Alloy.MixProject do
   use Mix.Project
 
-  @version "0.12.3"
+  @version "0.12.4"
   @source_url "https://github.com/alloy-ex/alloy"
 
   def project do
@@ -75,8 +75,8 @@ defmodule Alloy.MixProject do
         Core: [
           Alloy,
           Alloy.Agent.Config,
-          Alloy.Agent.Events,
           Alloy.Agent.Server,
+          Alloy.Events,
           Alloy.ModelCatalog,
           Alloy.ModelMetadata,
           Alloy.Agent.State,
@@ -109,6 +109,10 @@ defmodule Alloy.MixProject do
         ],
         Context: [
           Alloy.Context.Compactor
+        ],
+        Memory: [
+          Alloy.Memory,
+          Alloy.Memory.Router
         ],
         Middleware: [
           Alloy.Middleware

--- a/test/alloy/agent/config_test.exs
+++ b/test/alloy/agent/config_test.exs
@@ -2,6 +2,7 @@ defmodule Alloy.Agent.ConfigTest do
   use ExUnit.Case, async: true
 
   alias Alloy.Agent.Config
+  alias Alloy.Context.Compactor
   alias Alloy.ModelMetadata
 
   describe "max_tokens" do
@@ -76,11 +77,23 @@ defmodule Alloy.Agent.ConfigTest do
           max_tokens: 80
         )
 
-      assert config.compaction == %{
+      assert Map.take(config.compaction, [
+               :reserve_tokens,
+               :keep_recent_tokens,
+               :fallback,
+               :clear_tool_results,
+               :keep_recent_tool_results
+             ]) == %{
                reserve_tokens: 8,
                keep_recent_tokens: 10,
-               fallback: :truncate
+               fallback: :truncate,
+               clear_tool_results: true,
+               keep_recent_tool_results: 3
              }
+
+      assert config.compaction.summary_system_prompt == Compactor.default_summary_system_prompt()
+
+      assert config.compaction.summary_prompt == Compactor.default_summary_prompt()
     end
 
     test "accepts explicit compaction overrides" do
@@ -91,10 +104,18 @@ defmodule Alloy.Agent.ConfigTest do
           compaction: [reserve_tokens: 12, keep_recent_tokens: 34, fallback: :truncate]
         )
 
-      assert config.compaction == %{
+      assert Map.take(config.compaction, [
+               :reserve_tokens,
+               :keep_recent_tokens,
+               :fallback,
+               :clear_tool_results,
+               :keep_recent_tool_results
+             ]) == %{
                reserve_tokens: 12,
                keep_recent_tokens: 34,
-               fallback: :truncate
+               fallback: :truncate,
+               clear_tool_results: true,
+               keep_recent_tool_results: 3
              }
     end
 
@@ -105,11 +126,69 @@ defmodule Alloy.Agent.ConfigTest do
           max_tokens: 5
         )
 
-      assert config.compaction == %{
+      assert Map.take(config.compaction, [
+               :reserve_tokens,
+               :keep_recent_tokens,
+               :fallback,
+               :clear_tool_results,
+               :keep_recent_tool_results
+             ]) == %{
                reserve_tokens: 1,
                keep_recent_tokens: 1,
-               fallback: :truncate
+               fallback: :truncate,
+               clear_tool_results: true,
+               keep_recent_tool_results: 3
              }
+    end
+
+    test "accepts tool-result clearing compaction options" do
+      config =
+        Config.from_opts(
+          provider: {Alloy.Provider.Test, []},
+          compaction: [clear_tool_results: false, keep_recent_tool_results: 0]
+        )
+
+      assert config.compaction.clear_tool_results == false
+      assert config.compaction.keep_recent_tool_results == 0
+    end
+
+    test "validates tool-result clearing compaction options" do
+      assert_raise ArgumentError, ~r/clear_tool_results must be a boolean/, fn ->
+        Config.from_opts(
+          provider: {Alloy.Provider.Test, []},
+          compaction: [clear_tool_results: "false"]
+        )
+      end
+
+      assert_raise ArgumentError,
+                   ~r/keep_recent_tool_results must be a non-negative integer/,
+                   fn ->
+                     Config.from_opts(
+                       provider: {Alloy.Provider.Test, []},
+                       compaction: [keep_recent_tool_results: -1]
+                     )
+                   end
+    end
+
+    test "accepts and validates custom compaction prompts" do
+      config =
+        Config.from_opts(
+          provider: {Alloy.Provider.Test, []},
+          compaction: [
+            summary_system_prompt: "Summarize like my app expects.",
+            summary_prompt: "Return a compact handoff."
+          ]
+        )
+
+      assert config.compaction.summary_system_prompt == "Summarize like my app expects."
+      assert config.compaction.summary_prompt == "Return a compact handoff."
+
+      assert_raise ArgumentError, ~r/summary_prompt must be a string/, fn ->
+        Config.from_opts(
+          provider: {Alloy.Provider.Test, []},
+          compaction: [summary_prompt: :bad]
+        )
+      end
     end
   end
 end

--- a/test/alloy/agent/turn_test.exs
+++ b/test/alloy/agent/turn_test.exs
@@ -2110,6 +2110,68 @@ defmodule Alloy.Agent.TurnTest do
       assert is_integer(measurements.messages_before)
       assert is_integer(measurements.messages_after)
     end
+
+    test "emits matching turn metadata for compaction cleared and done events" do
+      test_pid = self()
+      handler_id = "compaction-turn-consistency-#{inspect(make_ref())}"
+
+      :telemetry.attach_many(
+        handler_id,
+        [[:alloy, :compaction, :cleared], [:alloy, :compaction, :done]],
+        fn event, _measurements, metadata, _config ->
+          send(test_pid, {:compaction_event, event, metadata.turn})
+        end,
+        nil
+      )
+
+      {:ok, pid} =
+        TestProvider.start_link([
+          TestProvider.text_response("ok")
+        ])
+
+      messages =
+        [Message.user("task")] ++
+          Enum.flat_map(1..6, fn index ->
+            id = "t#{index}"
+
+            [
+              Message.assistant_blocks([
+                %{type: "tool_use", id: id, name: "read_file", input: %{path: "file#{index}.txt"}}
+              ]),
+              Message.tool_results([
+                %{
+                  type: "tool_result",
+                  tool_use_id: id,
+                  content: String.duplicate("#{index}", 400)
+                }
+              ])
+            ]
+          end)
+
+      config = %Config{
+        provider: TestProvider,
+        provider_config: %{agent_pid: pid},
+        max_tokens: 540,
+        compaction: %{
+          reserve_tokens: 100,
+          keep_recent_tokens: 10,
+          fallback: :truncate,
+          clear_tool_results: true,
+          keep_recent_tool_results: 3
+        }
+      }
+
+      try do
+        state = State.init(config, messages)
+        _result = Turn.run_loop(state)
+
+        assert_received {:compaction_event, [:alloy, :compaction, :cleared], cleared_turn}
+        assert_received {:compaction_event, [:alloy, :compaction, :done], done_turn}
+        assert cleared_turn == done_turn
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
   end
 
   describe "prompt too long recovery" do

--- a/test/alloy/context/compactor_test.exs
+++ b/test/alloy/context/compactor_test.exs
@@ -112,6 +112,34 @@ defmodule Alloy.Context.CompactorTest do
 
   defp assistant_tool_call_message?(_message), do: false
 
+  defp tool_result_content(messages, id) do
+    messages
+    |> Enum.flat_map(fn
+      %Message{content: blocks} when is_list(blocks) -> blocks
+      _ -> []
+    end)
+    |> Enum.find_value(fn
+      %{type: "tool_result", tool_use_id: ^id, content: content} -> content
+      %{type: "server_tool_result", tool_use_id: ^id, content: content} -> content
+      _ -> nil
+    end)
+  end
+
+  defp bulky_tool_messages(count, size) do
+    Enum.flat_map(1..count, fn index ->
+      id = "t#{index}"
+
+      [
+        Message.assistant_blocks([
+          %{type: "tool_use", id: id, name: "read_file", input: %{path: "file#{index}.txt"}}
+        ]),
+        Message.tool_results([
+          %{type: "tool_result", tool_use_id: id, content: String.duplicate("#{index}", size)}
+        ])
+      ]
+    end)
+  end
+
   defp tool_pairs_intact?(messages) do
     Enum.with_index(messages)
     |> Enum.all?(fn
@@ -172,6 +200,201 @@ defmodule Alloy.Context.CompactorTest do
       assert Enum.at(compacted.messages, 1).role == :user
       assert summary_message?(Enum.at(compacted.messages, 1))
       assert Enum.at(compacted.messages, 1).content =~ "Alpha goal"
+    end
+
+    test "uses custom summary prompts from compaction config" do
+      messages = [
+        Message.user("original request"),
+        Message.assistant(String.duplicate("a", 900)),
+        Message.user("latest")
+      ]
+
+      state =
+        build_state(messages,
+          max_tokens: 250,
+          compaction: [
+            reserve_tokens: 25,
+            keep_recent_tokens: 20,
+            summary_system_prompt: "My app owns the compaction system prompt.",
+            summary_prompt: "CUSTOM HANDOFF FORMAT"
+          ],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("Custom")}, test_pid: self()}
+        )
+
+      {:compacted, _compacted} = Compactor.maybe_compact(state)
+
+      assert_received {:summary_request, [%Message{role: :user, content: prompt}], [], config}
+      assert config.system_prompt == "My app owns the compaction system prompt."
+      assert prompt =~ "CUSTOM HANDOFF FORMAT"
+    end
+
+    test "clears bulky old tool results before summarizing and skips provider when enough" do
+      messages =
+        [Message.user("original")] ++
+          bulky_tool_messages(5, 400) ++
+          [Message.user("latest")]
+
+      state =
+        build_state(messages,
+          max_tokens: 540,
+          compaction: [reserve_tokens: 100, keep_recent_tokens: 10],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("unused")}, test_pid: self()}
+        )
+
+      {:compacted, compacted} = Compactor.maybe_compact(state)
+
+      refute_received {:summary_request, _, _, _}
+      assert tool_result_content(compacted.messages, "t1") == "[tool result cleared: 400 bytes]"
+      assert tool_result_content(compacted.messages, "t2") == "[tool result cleared: 400 bytes]"
+      assert tool_result_content(compacted.messages, "t3") == String.duplicate("3", 400)
+      assert tool_result_content(compacted.messages, "t4") == String.duplicate("4", 400)
+      assert tool_result_content(compacted.messages, "t5") == String.duplicate("5", 400)
+    end
+
+    test "clears old tool results in a single-prompt tool loop before summarizing" do
+      messages = [Message.user("task")] ++ bulky_tool_messages(6, 400)
+
+      state =
+        build_state(messages,
+          max_tokens: 540,
+          compaction: [reserve_tokens: 100, keep_recent_tokens: 10],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("unused")}, test_pid: self()}
+        )
+
+      {:compacted, compacted} = Compactor.maybe_compact(state)
+
+      refute_received {:summary_request, _, _, _}
+      assert tool_result_content(compacted.messages, "t1") == "[tool result cleared: 400 bytes]"
+      assert tool_result_content(compacted.messages, "t2") == "[tool result cleared: 400 bytes]"
+      assert tool_result_content(compacted.messages, "t3") == "[tool result cleared: 400 bytes]"
+      assert tool_result_content(compacted.messages, "t4") == String.duplicate("4", 400)
+      assert tool_result_content(compacted.messages, "t5") == String.duplicate("5", 400)
+      assert tool_result_content(compacted.messages, "t6") == String.duplicate("6", 400)
+    end
+
+    test "emits telemetry when tool results are cleared" do
+      test_pid = self()
+      handler_id = "compaction-cleared-#{inspect(make_ref())}"
+
+      :telemetry.attach(
+        handler_id,
+        [:alloy, :compaction, :cleared],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:cleared, measurements, metadata})
+        end,
+        nil
+      )
+
+      messages =
+        [Message.user("original")] ++
+          bulky_tool_messages(4, 300) ++
+          [Message.user("latest")]
+
+      state =
+        build_state(messages,
+          max_tokens: 380,
+          compaction: [reserve_tokens: 100, keep_recent_tokens: 10],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("unused")}, test_pid: self()}
+        )
+
+      try do
+        {:compacted, _compacted} = Compactor.maybe_compact(state)
+        assert_received {:cleared, %{results_cleared: 1, bytes_cleared: 300}, %{turn: 1}}
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
+
+    test "falls through to summarization when clearing tool results is not enough" do
+      messages =
+        [Message.user("original")] ++
+          bulky_tool_messages(4, 200) ++
+          [Message.assistant(String.duplicate("analysis", 600)), Message.user("latest")]
+
+      state =
+        build_state(messages,
+          max_tokens: 600,
+          compaction: [reserve_tokens: 100, keep_recent_tokens: 10],
+          provider: ProbeProvider,
+          provider_config: %{
+            summary_response: {:ok, summary_text("ClearThenSummary")},
+            test_pid: self()
+          }
+        )
+
+      {:compacted, compacted} = Compactor.maybe_compact(state)
+
+      assert_received {:summary_request, _, _, _}
+      assert Enum.any?(compacted.messages, &summary_message?/1)
+    end
+
+    test "clear_tool_results false skips clearing and goes directly to summarization" do
+      messages =
+        [Message.user("original")] ++
+          bulky_tool_messages(4, 300) ++
+          [Message.user("latest")]
+
+      state =
+        build_state(messages,
+          max_tokens: 380,
+          compaction: [
+            reserve_tokens: 100,
+            keep_recent_tokens: 10,
+            clear_tool_results: false
+          ],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("NoClear")}, test_pid: self()}
+        )
+
+      {:compacted, compacted} = Compactor.maybe_compact(state)
+
+      assert_received {:summary_request, _, _, _}
+      assert Enum.any?(compacted.messages, &summary_message?/1)
+    end
+
+    test "tool-result clearing does not touch thinking blocks" do
+      signed_thinking = String.duplicate("signed", 80)
+      unsigned_thinking = String.duplicate("unsigned", 80)
+
+      reasoning = %{
+        type: "reasoning",
+        raw: %{
+          "id" => "rs_1",
+          "type" => "reasoning",
+          "encrypted_content" => "opaque"
+        }
+      }
+
+      messages =
+        [
+          Message.user("original"),
+          Message.assistant_blocks([
+            %{type: "thinking", thinking: signed_thinking, signature: "sig-1"},
+            %{type: "thinking", thinking: unsigned_thinking},
+            reasoning
+          ])
+        ] ++ bulky_tool_messages(4, 300) ++ [Message.user("latest")]
+
+      state =
+        build_state(messages,
+          max_tokens: 700,
+          compaction: [reserve_tokens: 100, keep_recent_tokens: 10],
+          provider: ProbeProvider,
+          provider_config: %{summary_response: {:ok, summary_text("unused")}, test_pid: self()}
+        )
+
+      {:compacted, compacted} = Compactor.maybe_compact(state)
+      thinking_message = Enum.at(compacted.messages, 1)
+
+      assert [
+               %{type: "thinking", thinking: ^signed_thinking, signature: "sig-1"},
+               %{type: "thinking", thinking: ^unsigned_thinking},
+               ^reasoning
+             ] = thinking_message.content
     end
 
     test "preserves recent messages intact based on the keep_recent_tokens budget" do
@@ -577,6 +800,31 @@ defmodule Alloy.Context.CompactorTest do
 
       compacted_msg = Enum.at(compacted, 1)
       assert String.length(compacted_msg.content) <= 203
+    end
+
+    test "drops signed thinking blocks instead of truncating them" do
+      signed = String.duplicate("s", 500)
+      unsigned = String.duplicate("u", 500)
+
+      messages = [
+        Message.user("original"),
+        Message.assistant_blocks([
+          %{type: "thinking", thinking: signed, signature: "signed-token"},
+          %{type: "thinking", thinking: unsigned},
+          %{type: "text", text: "after thinking"}
+        ]),
+        Message.assistant("recent"),
+        Message.user("latest")
+      ]
+
+      compacted = Compactor.compact_messages(messages, keep_recent: 2)
+
+      compacted_msg = Enum.at(compacted, 1)
+      refute Enum.any?(compacted_msg.content, &match?(%{signature: "signed-token"}, &1))
+      assert Enum.any?(compacted_msg.content, &match?(%{type: "thinking"}, &1))
+
+      unsigned_block = Enum.find(compacted_msg.content, &match?(%{type: "thinking"}, &1))
+      assert String.length(unsigned_block.thinking) <= 203
     end
 
     test "handles all messages within keep_recent window" do

--- a/test/alloy/message_test.exs
+++ b/test/alloy/message_test.exs
@@ -136,4 +136,26 @@ defmodule Alloy.MessageTest do
       assert Message.text(msg) == ""
     end
   end
+
+  describe "thinking/1" do
+    test "extracts and joins thinking blocks, ignoring text/tool blocks" do
+      msg =
+        Message.assistant_blocks([
+          %{type: "thinking", thinking: "step one"},
+          %{type: "text", text: "the answer"},
+          %{type: "thinking", thinking: "step two"}
+        ])
+
+      assert Message.thinking(msg) == "step one\nstep two"
+    end
+
+    test "returns nil for a string-content message" do
+      assert Message.thinking(Message.assistant("hi")) == nil
+    end
+
+    test "returns nil when no thinking blocks are present" do
+      msg = Message.assistant_blocks([%{type: "text", text: "the answer"}])
+      assert Message.thinking(msg) == nil
+    end
+  end
 end

--- a/test/alloy/provider/anthropic_test.exs
+++ b/test/alloy/provider/anthropic_test.exs
@@ -156,6 +156,32 @@ defmodule Alloy.Provider.AnthropicTest do
       assert tool["allowed_callers"] == ["human", "code_execution"]
     end
 
+    test "includes strict true on strict tools" do
+      config = config_that_captures_request()
+
+      tool_defs = [
+        %{
+          name: "search",
+          description: "Search",
+          strict: true,
+          input_schema: %{
+            type: "object",
+            properties: %{query: %{type: "string"}},
+            required: ["query"],
+            additionalProperties: false
+          }
+        }
+      ]
+
+      Anthropic.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert [tool] = decoded["tools"]
+      assert tool["strict"] == true
+    end
+
     test "omits allowed_callers from tool definition when not present" do
       config = config_that_captures_request()
 
@@ -201,6 +227,23 @@ defmodule Alloy.Provider.AnthropicTest do
       assert tool_result_msg["role"] == "user"
       assert is_list(tool_result_msg["content"])
       assert hd(tool_result_msg["content"])["type"] == "tool_result"
+    end
+
+    test "extra_body params merge into the request body" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:extra_body, %{
+          mcp_servers: [%{type: "url", url: "https://mcp.example.test"}]
+        })
+
+      Anthropic.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert decoded["mcp_servers"] == [
+               %{"type" => "url", "url" => "https://mcp.example.test"}
+             ]
     end
   end
 
@@ -255,6 +298,70 @@ defmodule Alloy.Provider.AnthropicTest do
         |> Enum.sort()
 
       assert merged_beta_values == ["code-execution-2025-08-25", "context-1m-2025-08-07"]
+    end
+
+    test "emits advanced tool-use fields and beta header when used" do
+      config = config_that_captures_request()
+
+      tool_defs = [
+        %{
+          name: "search",
+          description: "Search",
+          input_schema: %{type: "object", properties: %{query: %{type: "string"}}},
+          input_examples: [%{query: "release notes"}],
+          defer_loading: true
+        }
+      ]
+
+      Anthropic.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_body, body}
+      assert_received {:request_headers, headers}
+
+      decoded = Jason.decode!(body)
+      assert [tool] = decoded["tools"]
+      assert tool["input_examples"] == [%{"query" => "release notes"}]
+      assert tool["defer_loading"] == true
+
+      assert beta_values(headers) == ["advanced-tool-use-2025-11-20"]
+    end
+
+    test "advanced tool-use beta merges with memory beta" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:memory, {Alloy.Test.MemoryStore, %{}})
+
+      tool_defs = [
+        %{
+          name: "search",
+          description: "Search",
+          input_schema: %{type: "object", properties: %{}},
+          input_examples: [%{}]
+        }
+      ]
+
+      Anthropic.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_headers, headers}
+
+      assert beta_values(headers) == [
+               "advanced-tool-use-2025-11-20",
+               "context-management-2025-06-27"
+             ]
+    end
+
+    test "does not add advanced tool-use beta when advanced fields are absent" do
+      config = config_that_captures_request()
+
+      tool_defs = [
+        %{name: "read", description: "Read", input_schema: %{type: "object", properties: %{}}}
+      ]
+
+      Anthropic.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_headers, headers}
+
+      refute "advanced-tool-use-2025-11-20" in beta_values(headers)
     end
 
     test "does not include code_execution tool when code_execution is false" do
@@ -454,6 +561,118 @@ defmodule Alloy.Provider.AnthropicTest do
       assert List.last(tools)["cache_control"] == %{"type" => "ephemeral"}
     end
 
+    test "last message string content gets cache_control when cache: true" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:cache, true)
+
+      Anthropic.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      [message] = decoded["messages"]
+
+      assert [%{"type" => "text", "text" => "Hi", "cache_control" => %{"type" => "ephemeral"}}] =
+               message["content"]
+    end
+
+    test "last message block content gets cache_control on its last block" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:cache, true)
+
+      messages = [
+        %Message{
+          role: :user,
+          content: [
+            %{type: "text", text: "First"},
+            %{type: "text", text: "Second"}
+          ]
+        }
+      ]
+
+      Anthropic.complete(messages, [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      [message] = decoded["messages"]
+      [first, last] = message["content"]
+      refute Map.has_key?(first, "cache_control")
+      assert last["cache_control"] == %{"type" => "ephemeral"}
+    end
+
+    test "last message cache_control skips trailing thinking blocks" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:cache, true)
+
+      messages = [
+        %Message{
+          role: :assistant,
+          content: [
+            %{type: "text", text: "Prefill"},
+            %{type: "thinking", thinking: "Reasoning", signature: "sig_123"}
+          ]
+        }
+      ]
+
+      Anthropic.complete(messages, [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      [message] = decoded["messages"]
+      [text, thinking] = message["content"]
+
+      assert text["cache_control"] == %{"type" => "ephemeral"}
+      refute Map.has_key?(thinking, "cache_control")
+    end
+
+    test "last message cache_control is omitted when only thinking blocks qualify" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:cache, true)
+
+      messages = [
+        %Message{
+          role: :assistant,
+          content: [
+            %{type: "thinking", thinking: "Reasoning", signature: "sig_123"},
+            %{type: "redacted_thinking", data: "opaque"}
+          ]
+        }
+      ]
+
+      Anthropic.complete(messages, [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      [message] = decoded["messages"]
+      assert count_cache_controls(message) == 0
+    end
+
+    test "cache true keeps total cache_control breakpoints at three" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:system_prompt, "You are helpful.")
+        |> Map.put(:cache, true)
+
+      tool_defs = [
+        %{name: "read", description: "Read", input_schema: %{type: "object", properties: %{}}}
+      ]
+
+      Anthropic.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert count_cache_controls(decoded) <= 4
+      assert count_cache_controls(decoded) == 3
+    end
+
     test "tools have no cache_control when cache is not set" do
       config = config_that_captures_request()
 
@@ -472,6 +691,9 @@ defmodule Alloy.Provider.AnthropicTest do
 
       [tool] = decoded["tools"]
       refute Map.has_key?(tool, "cache_control")
+
+      [message] = decoded["messages"]
+      refute is_list(message["content"])
     end
 
     test "includes cache usage in response" do
@@ -1229,5 +1451,31 @@ defmodule Alloy.Provider.AnthropicTest do
         )
       end)
     end)
+  end
+
+  defp count_cache_controls(value) when is_map(value) do
+    own = if Map.has_key?(value, "cache_control"), do: 1, else: 0
+
+    own +
+      (value
+       |> Map.values()
+       |> Enum.map(&count_cache_controls/1)
+       |> Enum.sum())
+  end
+
+  defp count_cache_controls(value) when is_list(value) do
+    value
+    |> Enum.map(&count_cache_controls/1)
+    |> Enum.sum()
+  end
+
+  defp count_cache_controls(_value), do: 0
+
+  defp beta_values(headers) do
+    headers
+    |> Enum.filter(fn {name, _value} -> String.downcase(name) == "anthropic-beta" end)
+    |> Enum.flat_map(fn {_name, value} -> String.split(value, ",", trim: true) end)
+    |> Enum.map(&String.trim/1)
+    |> Enum.sort()
   end
 end

--- a/test/alloy/provider/codex_test.exs
+++ b/test/alloy/provider/codex_test.exs
@@ -295,6 +295,47 @@ defmodule Alloy.Provider.CodexTest do
       assert elapsed < 5_000,
              "expected timeout to fire within ~200ms + grace, took #{elapsed}ms"
     end
+
+    test "receive_timeout caps a larger timeout_ms for the real shell-backed run" do
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "alloy-codex-provider-receive-timeout-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(temp_dir)
+      on_exit(fn -> File.rm_rf(temp_dir) end)
+
+      auth_path = Path.join(temp_dir, "auth.json")
+      File.write!(auth_path, "{}")
+
+      script_path = Path.join(temp_dir, "slow-codex.sh")
+
+      File.write!(script_path, """
+      #!/bin/sh
+      cat > /dev/null
+      sleep 30
+      """)
+
+      File.chmod!(script_path, 0o755)
+
+      config = %{
+        model: "gpt-5.4",
+        codex_bin: script_path,
+        auth_path: auth_path,
+        timeout_ms: 30_000,
+        receive_timeout: 150
+      }
+
+      started_at = System.monotonic_time(:millisecond)
+      result = Codex.complete([Message.user("deadline")], [], config)
+      elapsed = System.monotonic_time(:millisecond) - started_at
+
+      assert {:error, "codex exec timed out after 150ms"} = result
+
+      assert elapsed < 5_000,
+             "expected receive_timeout to cap the port timeout, took #{elapsed}ms"
+    end
   end
 
   describe "stream/4" do

--- a/test/alloy/provider/gemini_test.exs
+++ b/test/alloy/provider/gemini_test.exs
@@ -128,6 +128,34 @@ defmodule Alloy.Provider.GeminiTest do
       assert {"x-goog-api-key", "gem-test-key"} in headers
     end
 
+    test "omits strict field because Gemini has no strict tool equivalent" do
+      config = config_that_captures_request()
+
+      Gemini.complete(
+        [Message.user("Hi")],
+        [
+          %{
+            name: "search",
+            description: "Search",
+            strict: true,
+            input_schema: %{
+              type: "object",
+              properties: %{query: %{type: "string"}},
+              required: ["query"],
+              additionalProperties: false
+            }
+          }
+        ],
+        config
+      )
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert [%{"functionDeclarations" => [tool]}] = decoded["tools"]
+      refute Map.has_key?(tool, "strict")
+    end
+
     test "formats tool results as function responses using the original tool call name" do
       config = config_that_captures_request()
 

--- a/test/alloy/provider/openai_compat_test.exs
+++ b/test/alloy/provider/openai_compat_test.exs
@@ -53,6 +53,34 @@ defmodule Alloy.Provider.OpenAICompatTest do
     end)
   end
 
+  describe "request formatting" do
+    test "includes strict true inside function tool definitions" do
+      config = config_that_captures_request()
+
+      tool_defs = [
+        %{
+          name: "search",
+          description: "Search",
+          strict: true,
+          input_schema: %{
+            type: "object",
+            properties: %{query: %{type: "string"}},
+            required: ["query"],
+            additionalProperties: false
+          }
+        }
+      ]
+
+      OpenAICompat.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert [%{"type" => "function", "function" => function}] = decoded["tools"]
+      assert function["strict"] == true
+    end
+  end
+
   # ── Gemini 3.x thought signatures (PR #24) ───────────────────────────
 
   describe "Gemini 3.x thought signatures" do

--- a/test/alloy/provider/openai_test.exs
+++ b/test/alloy/provider/openai_test.exs
@@ -95,6 +95,51 @@ defmodule Alloy.Provider.OpenAITest do
       tool_block = Enum.find(blocks, &(&1.type == "tool_use"))
       assert tool_block.name == "read"
     end
+
+    test "round-trips reasoning items before their function calls in stateless mode" do
+      reasoning = reasoning_item("rs_1", "encrypted-state")
+
+      config =
+        config_with_response(%{
+          status: 200,
+          body:
+            Jason.encode!(
+              response_payload([
+                reasoning,
+                function_call_item(
+                  "call_reasoned",
+                  "read",
+                  Jason.encode!(%{"file_path" => "mix.exs"})
+                )
+              ])
+            )
+        })
+
+      assert {:ok, result} = OpenAI.complete([Message.user("Read")], [], config)
+      assert [%Message{role: :assistant, content: blocks} = assistant_message] = result.messages
+      assert [%{type: "reasoning", raw: ^reasoning}, %{type: "tool_use"}] = blocks
+      assert Message.text(assistant_message) == ""
+
+      capture_config = config_that_captures_request()
+
+      messages = [
+        Message.user("Read"),
+        assistant_message,
+        Message.tool_results([
+          Message.tool_result_block("call_reasoned", "file contents")
+        ])
+      ]
+
+      OpenAI.complete(messages, [], capture_config)
+
+      assert_received {:request_body, body}
+      input = Jason.decode!(body)["input"]
+      reasoning_index = Enum.find_index(input, &(&1["type"] == "reasoning"))
+      function_index = Enum.find_index(input, &(&1["type"] == "function_call"))
+
+      assert Enum.at(input, reasoning_index) == reasoning
+      assert reasoning_index < function_index
+    end
   end
 
   describe "complete/3 request formatting" do
@@ -158,6 +203,55 @@ defmodule Alloy.Provider.OpenAITest do
       assert tool["parameters"]["type"] == "object"
     end
 
+    test "includes strict true on strict function tools" do
+      config = config_that_captures_request()
+
+      tool_defs = [
+        %{
+          name: "search",
+          description: "Search",
+          strict: true,
+          input_schema: %{
+            type: "object",
+            properties: %{query: %{type: "string"}},
+            required: ["query"],
+            additionalProperties: false
+          }
+        }
+      ]
+
+      OpenAI.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert [tool] = decoded["tools"]
+      assert tool["strict"] == true
+    end
+
+    test "omits Anthropic advanced-tool-use fields" do
+      config = config_that_captures_request()
+
+      tool_defs = [
+        %{
+          name: "search",
+          description: "Search",
+          input_schema: %{type: "object", properties: %{query: %{type: "string"}}},
+          input_examples: [%{query: "release notes"}],
+          defer_loading: true
+        }
+      ]
+
+      OpenAI.complete([Message.user("Hi")], tool_defs, config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert [tool] = decoded["tools"]
+      refute Map.has_key?(tool, "input_examples")
+      refute Map.has_key?(tool, "defer_loading")
+    end
+
     test "formats tool flow as function_call + function_call_output input items" do
       config = config_that_captures_request()
 
@@ -214,6 +308,68 @@ defmodule Alloy.Provider.OpenAITest do
       assert decoded["include"] == ["inline_citations"]
       assert decoded["tool_choice"] == "required"
       assert decoded["parallel_tool_calls"] == false
+    end
+
+    test "stateless requests include encrypted reasoning content" do
+      config = config_that_captures_request()
+
+      OpenAI.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert decoded["include"] == ["reasoning.encrypted_content"]
+    end
+
+    test "previous_response_id requests do not include encrypted reasoning content" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:previous_response_id, "resp_prev")
+
+      OpenAI.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert decoded["previous_response_id"] == "resp_prev"
+      refute Map.has_key?(decoded, "include")
+    end
+
+    test "stateless reasoning include merges with caller include values" do
+      config =
+        config_that_captures_request()
+        |> Map.put(:include, ["inline_citations"])
+
+      OpenAI.complete([Message.user("Hi")], [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      assert decoded["include"] == ["inline_citations", "reasoning.encrypted_content"]
+    end
+
+    test "store true does not add encrypted reasoning include or echo raw reasoning blocks" do
+      reasoning = reasoning_item("rs_store", "encrypted-state")
+
+      config =
+        config_that_captures_request()
+        |> Map.put(:store, true)
+
+      messages = [
+        Message.assistant_blocks([
+          %{type: "reasoning", raw: reasoning},
+          %{type: "tool_use", id: "call_1", name: "read", input: %{}}
+        ])
+      ]
+
+      OpenAI.complete(messages, [], config)
+
+      assert_received {:request_body, body}
+      decoded = Jason.decode!(body)
+
+      refute Map.has_key?(decoded, "include")
+      refute Enum.any?(decoded["input"], &(&1["type"] == "reasoning"))
+      assert Enum.any?(decoded["input"], &(&1["type"] == "function_call"))
     end
 
     test "explicit previous_response_id overrides provider_state response_id" do
@@ -686,6 +842,15 @@ defmodule Alloy.Provider.OpenAITest do
       "call_id" => call_id,
       "name" => name,
       "arguments" => arguments
+    }
+  end
+
+  defp reasoning_item(id, encrypted_content) do
+    %{
+      "id" => id,
+      "type" => "reasoning",
+      "summary" => [],
+      "encrypted_content" => encrypted_content
     }
   end
 

--- a/test/alloy/result_test.exs
+++ b/test/alloy/result_test.exs
@@ -9,6 +9,7 @@ defmodule Alloy.ResultTest do
       result = %Result{}
 
       assert result.text == nil
+      assert result.thinking == nil
       assert result.messages == []
       assert result.usage == %Alloy.Usage{}
       assert result.tool_calls == []
@@ -127,6 +128,37 @@ defmodule Alloy.ResultTest do
       assert result.usage.input_tokens == 10
       assert result.request_id == nil
       assert length(result.messages) == 2
+    end
+
+    test "surfaces the final assistant thinking text" do
+      config = %Config{provider: Alloy.Provider.Test, provider_config: %{}}
+
+      reasoning =
+        Message.assistant_blocks([
+          %{type: "thinking", thinking: "let me reason"},
+          %{type: "text", text: "the answer"}
+        ])
+
+      result =
+        config
+        |> State.init([Message.user("hello")])
+        |> State.append_messages([reasoning])
+        |> Result.from_state()
+
+      assert result.text == "the answer"
+      assert result.thinking == "let me reason"
+    end
+
+    test "thinking is nil when the model returned no thinking blocks" do
+      config = %Config{provider: Alloy.Provider.Test, provider_config: %{}}
+
+      result =
+        config
+        |> State.init([Message.user("hello")])
+        |> State.append_messages([Message.assistant("plain answer")])
+        |> Result.from_state()
+
+      assert result.thinking == nil
     end
   end
 

--- a/test/alloy/testing_test.exs
+++ b/test/alloy/testing_test.exs
@@ -58,6 +58,15 @@ defmodule Alloy.TestingTest do
       assert result.status == :completed
       assert_received {:ctx, %{tenant: "acme"}}
     end
+
+    test "default tools are shipped with the application" do
+      app_modules = Application.spec(:alloy, :modules)
+
+      assert Enum.all?(Alloy.Testing.default_tools(), fn
+               %Alloy.Tool.Inline{} -> true
+               module when is_atom(module) -> module in app_modules
+             end)
+    end
   end
 
   describe "assert_tool_called/2" do

--- a/test/alloy/tool/executor_test.exs
+++ b/test/alloy/tool/executor_test.exs
@@ -138,12 +138,56 @@ defmodule Alloy.Tool.ExecutorTest do
       state = build_state([CrashingTool])
       tool_call = %{id: "call_crash", name: "crasher", type: "tool_use", input: %{}}
 
-      result = Executor.execute_all([tool_call], state.tool_fns, state)
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          result = Executor.execute_all([tool_call], state.tool_fns, state)
 
-      assert %Message{role: :user, content: [block]} = result
-      assert block.content =~ "Tool crashed"
-      assert block.content =~ "boom!"
-      assert block.is_error == true
+          assert %Message{role: :user, content: [block]} = result
+          assert block.content =~ "Tool crasher crashed: boom!"
+          assert block.content =~ "CrashingTool.execute/2"
+          assert block.content =~ "Check the input and try again."
+          refute block.content =~ "\n"
+          refute block.content =~ "lib/alloy"
+          assert block.is_error == true
+        end)
+
+      assert log =~ "Tool crasher crashed: boom!"
+      assert log =~ "CrashingTool.execute/2"
+      assert log =~ "lib/alloy/tool/executor.ex"
+    end
+
+    test "exception telemetry keeps full stacktrace while model-visible result is short" do
+      state = build_state([CrashingTool])
+      tool_call = %{id: "call_crash", name: "crasher", type: "tool_use", input: %{}}
+      test_pid = self()
+
+      stop_handler_id = "tool-error-telemetry-#{inspect(make_ref())}"
+
+      :telemetry.attach(
+        stop_handler_id,
+        [:alloy, :tool, :stop],
+        fn _event, _measurements, metadata, _config ->
+          send(test_pid, {:tool_stop, metadata})
+        end,
+        nil
+      )
+
+      try do
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, %Message{role: :user, content: [block]}, [_meta]} =
+                   Executor.execute_all([tool_call], state.tool_fns, state,
+                     on_event: fn _ -> :ok end
+                   )
+
+          refute block.content =~ "\n"
+        end)
+
+        assert_receive {:tool_stop, %{error: error}}
+        assert error =~ "boom!"
+        assert error =~ "lib/alloy/tool/executor.ex"
+      after
+        :telemetry.detach(stop_handler_id)
+      end
     end
 
     test "tool returning {:error, reason} produces is_error block" do
@@ -274,7 +318,10 @@ defmodule Alloy.Tool.ExecutorTest do
 
       assert %Message{role: :user, content: [block]} = result
       assert block.tool_use_id == "call_slow"
-      assert block.content =~ "crashed"
+
+      assert block.content ==
+               "Tool slow_echo timed out after 50ms. Try a smaller input or raise :tool_timeout."
+
       assert block.is_error == true
     end
 

--- a/test/alloy/tool/inline_test.exs
+++ b/test/alloy/tool/inline_test.exs
@@ -71,6 +71,22 @@ defmodule Alloy.Tool.InlineTest do
         weather_tool(timeout: 5_000)
       end
     end
+
+    test "validates strict option type" do
+      assert_raise ArgumentError, ~r/:strict must be a boolean/, fn ->
+        weather_tool(strict: "yes")
+      end
+    end
+
+    test "validates advanced-tool-use option types" do
+      assert_raise ArgumentError, ~r/:input_examples must be a list of maps/, fn ->
+        weather_tool(input_examples: ["bad"])
+      end
+
+      assert_raise ArgumentError, ~r/:defer_loading must be a boolean/, fn ->
+        weather_tool(defer_loading: "yes")
+      end
+    end
   end
 
   describe "Registry with inline tools" do
@@ -94,6 +110,43 @@ defmodule Alloy.Tool.InlineTest do
 
       assert def_with.allowed_callers == [:human]
       assert def_with.result_type == :structured
+    end
+
+    test "inline strict tools require additionalProperties false" do
+      assert_raise ArgumentError,
+                   ~r/strict tool "get_weather" input_schema must include additionalProperties: false/,
+                   fn ->
+                     Registry.build([weather_tool(strict: true)])
+                   end
+
+      {[def_with], _} =
+        Registry.build([
+          weather_tool(
+            strict: true,
+            input_schema: %{
+              type: "object",
+              properties: %{location: %{type: "string"}},
+              required: ["location"],
+              additionalProperties: false
+            }
+          )
+        ])
+
+      assert def_with.strict == true
+    end
+
+    test "inline advanced-tool-use fields appear in defs only when set" do
+      {[def_without], _} = Registry.build([weather_tool()])
+      refute Map.has_key?(def_without, :input_examples)
+      refute Map.has_key?(def_without, :defer_loading)
+
+      {[def_with], _} =
+        Registry.build([
+          weather_tool(input_examples: [%{location: "Sydney"}], defer_loading: true)
+        ])
+
+      assert def_with.input_examples == [%{location: "Sydney"}]
+      assert def_with.defer_loading == true
     end
 
     test "rejects things that are neither modules nor inline tools" do
@@ -140,7 +193,9 @@ defmodule Alloy.Tool.InlineTest do
           TestProvider.text_response("Tool crashed.")
         ])
 
-      assert [%{name: "get_weather", error: "Tool crashed: boom"}] = result.tool_calls
+      assert [%{name: "get_weather", error: error}] = result.tool_calls
+      assert error =~ "boom"
+      assert error =~ "lib/alloy/tool/executor.ex"
     end
 
     test "structured 3-tuple results carry structured data" do

--- a/test/alloy/tool/registry_test.exs
+++ b/test/alloy/tool/registry_test.exs
@@ -48,6 +48,57 @@ defmodule Alloy.Tool.RegistryTest do
     def allowed_callers, do: [:human]
   end
 
+  defmodule StrictTool do
+    @behaviour Alloy.Tool
+    @impl true
+    def name, do: "strict_tool"
+    @impl true
+    def description, do: "A strict tool"
+    @impl true
+    def input_schema,
+      do: %{
+        type: "object",
+        properties: %{query: %{type: "string"}},
+        required: ["query"],
+        additionalProperties: false
+      }
+
+    @impl true
+    def execute(_input, _ctx), do: {:ok, "ok"}
+    @impl true
+    def strict?, do: true
+  end
+
+  defmodule InvalidStrictTool do
+    @behaviour Alloy.Tool
+    @impl true
+    def name, do: "invalid_strict"
+    @impl true
+    def description, do: "A strict tool with a loose schema"
+    @impl true
+    def input_schema, do: %{type: "object", properties: %{query: %{type: "string"}}}
+    @impl true
+    def execute(_input, _ctx), do: {:ok, "ok"}
+    @impl true
+    def strict?, do: true
+  end
+
+  defmodule AdvancedTool do
+    @behaviour Alloy.Tool
+    @impl true
+    def name, do: "advanced"
+    @impl true
+    def description, do: "An advanced tool"
+    @impl true
+    def input_schema, do: %{type: "object", properties: %{query: %{type: "string"}}}
+    @impl true
+    def execute(_input, _ctx), do: {:ok, "ok"}
+    @impl true
+    def input_examples, do: [%{query: "release notes"}]
+    @impl true
+    def defer_loading?, do: true
+  end
+
   describe "build/1" do
     test "basic tool produces definitions without metadata" do
       {defs, fns} = Registry.build([BasicTool])
@@ -101,6 +152,39 @@ defmodule Alloy.Tool.RegistryTest do
 
     test "empty tool list returns empty results" do
       assert Registry.build([]) == {[], %{}}
+    end
+
+    test "strict tools include strict metadata" do
+      {defs, _fns} = Registry.build([StrictTool])
+
+      assert [%{name: "strict_tool", strict: true}] = defs
+    end
+
+    test "strict tools must set additionalProperties false" do
+      error =
+        assert_raise ArgumentError, fn ->
+          Registry.build([InvalidStrictTool])
+        end
+
+      message = Exception.message(error)
+
+      assert message =~
+               ~s(strict tool "invalid_strict" input_schema must include additionalProperties: false)
+
+      assert message =~
+               "OpenAI strict mode also requires every property to be listed in required."
+    end
+
+    test "advanced tool metadata is included only when present" do
+      {defs, _fns} = Registry.build([AdvancedTool, BasicTool])
+
+      advanced_def = Enum.find(defs, &(&1.name == "advanced"))
+      assert advanced_def.input_examples == [%{query: "release notes"}]
+      assert advanced_def.defer_loading == true
+
+      basic_def = Enum.find(defs, &(&1.name == "basic"))
+      refute Map.has_key?(basic_def, :input_examples)
+      refute Map.has_key?(basic_def, :defer_loading)
     end
   end
 end


### PR DESCRIPTION
## One release, everything from the July 2026 audit

This PR consolidates the full audit + frontier-lab gap-analysis backlog into a single release, per the one-release decision. **It subsumes #42 and #43** (their commits are cherry-picked here verbatim) — merging this PR delivers both; they can then be closed.

Implemented by Codex (programmatic mode, 2 rounds) under Claude review. Round-2 review caught and fixed: tool-result clearing being dead in the canonical single-prompt agent shape, and the tail cache breakpoint landing on thinking blocks (Anthropic 400).

### Fixed
- **`Alloy.Testing` default tools now ship in Hex** — was an unshipped `test/support` module; any consumer using `run_with_responses/2` without `:tools` hit `UndefinedFunctionError`
- **Signed thinking blocks dropped, never truncated** in fallback compaction — Anthropic rejects modified thinking blocks; Gemini 3 hard-400s on altered `thoughtSignature`
- **Model-legible tool errors** — one actionable line to the model; full stacktrace stays in Logger/telemetry (per Anthropic tool-design guidance)
- **Codex provider honours the turn deadline** (`:receive_timeout` caps the port timeout)

### Added
- **Batched tool-result clearing before summary compaction** — the [highest-ROI compaction primitive](https://claude.com/blog/context-management) (−84% tokens in Anthropic's 100-turn eval); one batch amortizes cache invalidation; `[:alloy, :compaction, :cleared]` telemetry; canonical single-prompt tool-loop regression test
- **User-owned compaction prompts** (`:summary_system_prompt`, `:summary_prompt`) — 12-Factor #2
- **OpenAI Responses reasoning-item persistence** — stateless calls request `reasoning.encrypted_content` and round-trip reasoning items verbatim before their function calls; GPT-5.x no longer loses reasoning between tool calls
- **Strict tool schemas** (`strict?/0` / `strict: true`) for Anthropic, OpenAI, OpenAICompat, with fail-fast `additionalProperties: false` validation
- **Anthropic advanced tool use passthrough** — `input_examples`, `defer_loading`, auto-merged `advanced-tool-use-2025-11-20` beta header
- **Anthropic conversation-tail cache breakpoint** — multi-turn runs stop re-paying full input price every turn (skips thinking blocks)
- **Anthropic `extra_body`** — enables server-side remote MCP via `mcp_servers` (documented in the MCP recipe)

### Docs
README Non-goals section (Pi philosophy: sub-agents recipe, no orchestration subsystem), compaction cache trade-off, strict-mode guidance, ExDoc grouping fix (`Alloy.Events` → Core, deprecated shim ungrouped, new Memory group), line-count claim updated.

### Verification
`mix format --check-formatted` ✓ · `mix credo --strict` 0 issues · **670 tests, 0 failures** (+41 new) · `mix dialyzer` 0 errors · Elixir 1.20/OTP 28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8DQQyoKwmsD3PsW9Gd8tM