### PR TITLE
fix(codex): collect port output when the process exits before os_pid is read

### DIFF
--- a/lib/alloy/provider/codex.ex
+++ b/lib/alloy/provider/codex.ex
@@ -271,9 +271,12 @@ defmodule Alloy.Provider.Codex do
         ]
       )
 
+    # Port.info/2 returns nil when the process already exited — its output
+    # and exit_status messages are still in the mailbox, so collect them;
+    # there is just no OS pid left to kill on timeout.
     case Port.info(port, :os_pid) do
       {:os_pid, os_pid} -> collect_port(port, os_pid, timeout, [])
-      nil -> {:error, "codex exec port closed before os_pid was available"}
+      nil -> collect_port(port, nil, timeout, [])
     end
   rescue
     error in ErlangError ->
@@ -311,6 +314,8 @@ defmodule Alloy.Provider.Codex do
 
   # SIGTERM with a 100ms grace window, then SIGKILL. Best-effort — if
   # codex has already exited, the second kill is a no-op.
+  defp kill_os_process(nil), do: :ok
+
   defp kill_os_process(os_pid) do
     _ = System.cmd("/bin/kill", ["-TERM", Integer.to_string(os_pid)], stderr_to_stdout: true)
     Process.sleep(100)

--- a/test/alloy/provider/codex_test.exs
+++ b/test/alloy/provider/codex_test.exs
@@ -251,6 +251,62 @@ defmodule Alloy.Provider.CodexTest do
       assert result.messages == [Message.assistant("stdin ok")]
     end
 
+    test "collects output even when the process exits before os_pid can be read" do
+      # Regression: Port.info(port, :os_pid) returns nil when the spawned
+      # process has already exited. The output and exit_status messages are
+      # still in the mailbox, so a fast-exiting codex must succeed, not
+      # error with "port closed before os_pid was available". The race is
+      # timing-dependent; the instant-exit script plus repetition makes it
+      # likely under the old code and proves the nil branch under the new.
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "alloy-codex-provider-fastexit-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(temp_dir)
+      on_exit(fn -> File.rm_rf(temp_dir) end)
+
+      auth_path = Path.join(temp_dir, "auth.json")
+      File.write!(auth_path, "{}")
+
+      script_path = Path.join(temp_dir, "fast-codex.sh")
+
+      File.write!(
+        script_path,
+        """
+        #!/bin/sh
+        output=""
+
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "--output-last-message" ]; then
+            shift
+            output="$1"
+          fi
+
+          shift
+        done
+
+        cat > /dev/null
+        printf '%s' '{"stop_reason":"end_turn","text":"fast exit","tool_calls":[]}' > "$output"
+        printf '%s\\n' '{"event":"done"}'
+        """
+      )
+
+      File.chmod!(script_path, 0o755)
+
+      config = %{
+        model: "gpt-5.4",
+        codex_bin: script_path,
+        auth_path: auth_path
+      }
+
+      for _run <- 1..20 do
+        assert {:ok, result} = Codex.complete([Message.user("Hi")], [], config)
+        assert result.messages == [Message.assistant("fast exit")]
+      end
+    end
+
     test "returns a timeout error instead of hanging when the real shell-backed run exceeds timeout_ms" do
       temp_dir =
         Path.join(


### PR DESCRIPTION
Fixes the flaky CI failure on main (`codex_test.exs` stdin test): `Port.info(port, :os_pid)` returns `nil` when the spawned process already exited, but the old code turned that into an error even though the port's output and exit_status messages were sitting in the mailbox. Fast-exiting codex processes now collect normally; `kill_os_process(nil)` no-ops.

Regression test: instant-exit fake codex script run 20×.

Verification: 671 tests 0 failures, codex suite ×3 locally, credo --strict clean, dialyzer 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8DQQyoKwmsD3PsW9Gd8tM