### PR TITLE
chore: pin dev toolchain to CI primary (Elixir 1.20.2-otp-28)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 28.4.2
+elixir 1.20.2-otp-28

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,14 @@ Rule of thumb: if it needs a database table, product defaults, or tenancy logic,
 git clone https://github.com/alloy-ex/alloy.git
 cd alloy
 mix deps.get
-mix test          # 533 tests, should all pass
+mix test          # 671 tests, should all pass
 ```
+
+The dev toolchain is pinned in `.tool-versions` (works with mise and asdf) to
+match CI's primary matrix leg — Elixir 1.20 brings the gradual type checker,
+so `mix compile --warnings-as-errors` locally catches what CI would. The
+library itself still supports `~> 1.17`; the pin is for contributors, not
+consumers.
 
 ## Development workflow
 


### PR DESCRIPTION
Adds `.tool-versions` (mise/asdf compatible) pinning the dev toolchain to the CI matrix's primary leg: Elixir 1.20.2-otp-28 on Erlang 28.4.2. Motivation: local/CI parity and the 1.20 gradual type checker running locally — this session, CI-only type warnings couldn't be reproduced on the unpinned local toolchain.

The library floor stays `~> 1.17` (consumers unaffected; the pin is contributor tooling only, excluded from the Hex package).

Verified: full recompile + 671 tests green ×3 under the pinned toolchain. One cold-start flake on the first post-recompile run did not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8DQQyoKwmsD3PsW9Gd8tM