### PR TITLE
chore: test the promised 1.17 floor in CI; ignore local tooling dirs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,16 @@ jobs:
         include:
           - elixir: "1.20"
             otp: "28"
+            lint: true
           - elixir: "1.19"
             otp: "27"
+            lint: true
+          # Floor leg: mix.exs promises ~> 1.17, so compile + test it.
+          # Lint/format/dialyzer stay on the modern legs — formatter output
+          # and warning sets differ across Elixir versions.
+          - elixir: "1.17"
+            otp: "26"
+            lint: false
 
     steps:
       - uses: actions/checkout@v5
@@ -50,7 +58,13 @@ jobs:
 
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
+        if: ${{ matrix.lint }}
+      - run: mix compile
+        if: ${{ !matrix.lint }}
       - run: mix test
       - run: mix format --check-formatted
+        if: ${{ matrix.lint }}
       - run: mix credo --strict
+        if: ${{ matrix.lint }}
       - run: mix dialyzer
+        if: ${{ matrix.lint }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ alloy-*.tar
 
 # Local tooling state.
 .claude/specs/
+.claude/worktrees/
+.codex/
+/automation/
 
 priv/plts/
 

--- a/test/alloy/tool/executor_test.exs
+++ b/test/alloy/tool/executor_test.exs
@@ -182,7 +182,7 @@ defmodule Alloy.Tool.ExecutorTest do
           refute block.content =~ "\n"
         end)
 
-        assert_receive {:tool_stop, %{error: error}}
+        assert_receive {:tool_stop, %{tool_name: "crasher", error: error}}
         assert error =~ "boom!"
         assert error =~ "lib/alloy/tool/executor.ex"
       after


### PR DESCRIPTION
mix.exs promises `~> 1.17` but CI only tested 1.19/1.20 — the floor was an untested claim. Adds a 1.17/OTP 26 compile+test leg (lint stays on modern legs since formatter/warning behaviour differs across versions). If this leg fails, the honest alternative is bumping the floor to `~> 1.19` — this PR is the experiment that decides.

Also gitignores `.codex/`, `automation/`, `.claude/worktrees/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8DQQyoKwmsD3PsW9Gd8tM