### PR TITLE
docs: announcement posts for 0.12.4

### DIFF
--- a/announcements/v0.12.4-posts.md
+++ b/announcements/v0.12.4-posts.md
@@ -1,0 +1,96 @@
+# Alloy 0.12.4 announcement posts
+
+Ready to paste. Forum first, then X, then LinkedIn.
+
+---
+
+## Elixir Forum
+
+### Alloy 0.12.4 — cache-aware compaction, strict tools, reasoning persistence
+
+[Alloy](https://hex.pm/packages/alloy) is a minimal agent harness for the BEAM — the completion-tool-call loop and nothing else. 0.12.4 is a provider-fidelity release: most of it comes from auditing the harness against what the frontier labs published about agent design over the last year.
+
+### Tool-result clearing before summarization
+
+Anthropic measured tool-result clearing cutting token use by 84% in a 100-turn agent eval — they call it the "safest, lightest touch" form of compaction. Alloy now does it client-side for every provider: when a conversation goes over budget, old tool results are cleared in one batch (newest N preserved) before any summarizer call. Most long runs never pay for an LLM summary at all.
+
+```elixir
+Alloy.run(input,
+  provider: provider,
+  compaction: [
+    clear_tool_results: true,       # default
+    keep_recent_tool_results: 3,    # newest results kept verbatim
+    summary_prompt: "..."           # the summary prompt is yours now, too
+  ]
+)
+```
+
+Clearing is batched deliberately: mutating history invalidates cached prompt prefixes, so one big clear amortises the cache cost instead of dripping invalidations across turns. The `[:alloy, :compaction, :cleared]` telemetry event reports what was freed.
+
+### Strict tool schemas
+
+Both Anthropic and OpenAI now recommend strict schema enforcement for tool calls — grammar-constrained sampling means tool inputs are guaranteed to match your JSON Schema. Opt in per tool:
+
+```elixir
+@impl true
+def strict?, do: true   # or strict: true on an inline tool
+```
+
+Alloy emits the right wire format per provider and fails fast at registry build if your schema is missing `additionalProperties: false` — no silent schema rewriting.
+
+### Reasoning persistence for OpenAI Responses
+
+GPT-5.x reasoning models return reasoning items between tool calls, and OpenAI recommends passing them all back. Alloy now round-trips them verbatim in stateless mode (with `reasoning.encrypted_content` requested automatically), so your agent keeps its train of thought across the tool loop instead of re-deriving it every turn.
+
+### Also in this release
+
+- Multi-turn Anthropic runs with `cache: true` get a conversation-tail cache breakpoint — you stop re-paying full input price on the whole history every turn
+- Signed thinking blocks are never truncated during compaction (Gemini 3 and Anthropic both hard-reject modified signed blocks)
+- Tool crashes send the model one actionable line; the full stacktrace stays in your logs and telemetry
+- `input_examples` and `defer_loading` passthrough for Anthropic's advanced tool use
+- Fixed: `Alloy.Testing`'s default tool referenced a module that never shipped in the Hex package
+- Assistant thinking is now surfaced on the run result (`result.thinking`)
+
+### Non-goals, written down
+
+The README now has an explicit Non-goals section. The headline: Alloy has no multi-agent subsystem, on purpose — a sub-agent is a tool whose `execute/2` calls `Alloy.run/2`. The agent spawns itself. Same philosophy as [Pi](https://github.com/badlogic/pi-mono): a harness, not a framework. Still 3 dependencies, ~9k lines, 671 tests.
+
+### Links
+
+- Hex: https://hex.pm/packages/alloy
+- Changelog: https://github.com/alloy-ex/alloy/blob/main/CHANGELOG.md
+- Docs: https://hexdocs.pm/alloy
+
+Feedback and PRs welcome.
+
+---
+
+## X
+
+Alloy 0.12.4 — agent harness for Elixir
+
+Anthropic measured tool-result clearing at -84% tokens in long agent runs. Alloy now does it for every provider: old tool results cleared in one cache-aware batch before any summarizer call. Most runs never pay for a summary again.
+
+Also: strict tool schemas (grammar-constrained inputs, Anthropic + OpenAI), GPT-5.x reasoning persisted across tool calls, conversation-tail prompt caching.
+
+Still a loop, 4 tools, 3 deps, ~9k lines. No multi-agent subsystem — the agent spawns itself.
+
+hex.pm/packages/alloy
+
+---
+
+## LinkedIn
+
+Alloy 0.12.4 is out — the minimal agent harness for Elixir.
+
+This release came from an unusual process: we audited the codebase against everything the frontier labs (Anthropic, OpenAI, Google) published about agent harness design, then implemented the gaps. Three highlights:
+
+1. Tool-result clearing before summarization. Anthropic measured this at -84% token use in long agent runs. Alloy now clears old tool results in one cache-aware batch before ever calling a summarizer — most long-running agents never pay for an LLM summary again.
+
+2. Strict tool schemas. Tool inputs are grammar-constrained to your JSON Schema on Anthropic and OpenAI. A whole class of validate-and-retry code disappears.
+
+3. Reasoning persistence. GPT-5.x models think between tool calls; Alloy now round-trips that reasoning so agents keep their train of thought through the loop.
+
+The philosophy stays the same: a loop, four tools, three dependencies, ~9,000 lines. We also wrote down what Alloy will never do — there's no multi-agent subsystem because a sub-agent is just a function call. The agent spawns itself.
+
+https://hex.pm/packages/alloy


### PR DESCRIPTION
Ready-to-paste announcement copy for the 0.12.4 release: Elixir Forum post, X post, LinkedIn post. Lead story is batched cache-aware tool-result clearing (Anthropic's -84% number), then strict tools and GPT-5.x reasoning persistence. Follows the v0.10.0-posts.md pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8DQQyoKwmsD3PsW9Gd8tM